### PR TITLE
build: port to meson

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,0 +1,18 @@
+icon_dirs = [
+  '16x16',
+  '24x24',
+  '32x32',
+  '48x48',
+  '256x256',
+  '512x512',
+]
+
+hicolor_icondir = get_option('datadir') / 'icons' / 'hicolor'
+
+foreach i:icon_dirs
+  install_data(
+    i / 'gnome-pomodoro.png',
+    install_dir: hicolor_icondir / i / 'apps',
+  )
+endforeach
+

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,39 @@
+dbus_conf = configuration_data()
+
+dbus_conf.set(
+  'bindir',
+  get_option('prefix') / get_option('bindir'),
+)
+
+configure_file(
+  input: 'org.gnome.Pomodoro.service.in',
+  output: '@BASENAME@',
+  configuration: dbus_conf,
+  install_dir: get_option('datadir') / 'dbus-1' / 'services',
+)
+
+i18n.merge_file(
+  input: 'org.gnome.Pomodoro.desktop.in',
+  output: '@BASENAME@',
+  install: true,
+  install_dir:  get_option('datadir') / 'applications',
+  po_dir: '..' / 'po',
+  type: 'desktop',
+)
+
+i18n.merge_file(
+  input: 'org.gnome.Pomodoro.appdata.xml.in',
+  output: '@BASENAME@',
+  install: true,
+  install_dir: get_option('datadir') / 'metainfo',
+  po_dir: '..' / 'po',
+)
+
+install_data(
+  'org.gnome.pomodoro.gschema.xml',
+  install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
+)
+
+subdir('icons')
+subdir('resources')
+subdir('sounds')

--- a/data/resources/meson.build
+++ b/data/resources/meson.build
@@ -1,0 +1,6 @@
+gnome_pomodoro_generated_sources = gnome.compile_resources(
+  'gnome-pomodoro-generated',
+  'resources.xml',
+  c_name: 'pomodoro',
+)
+

--- a/data/sounds/meson.build
+++ b/data/sounds/meson.build
@@ -1,0 +1,14 @@
+sounds = [
+  'bell.ogg',
+  'birds.ogg',
+  'clock.ogg',
+  'loud-bell.ogg',
+  'timer.ogg',
+]
+
+foreach s:sounds
+  install_data(
+    s,
+    install_dir: package_datadir / 'sounds',
+  )
+endforeach

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,64 @@
+libgnome_pomodoro_vala_sources = [
+  'about-dialog.vala',
+  'accelerator.vala',
+  'aggregated-entry.vala',
+  'animation.vala',
+  'application.vala',
+  'capability-group.vala',
+  'capability-manager.vala',
+  'capability.vala',
+  'desktop-extension.vala',
+  'entry.vala',
+  'log-scale.vala',
+  'notifications-capability.vala',
+  'preferences-dialog.vala',
+  'presence.vala',
+  'screen-notification.vala',
+  'service.vala',
+  'settings.vala',
+  'stats-page.vala',
+  'stats-view.vala',
+  'stats-day-page.vala',
+  'stats-week-page.vala',
+  'stats-month-page.vala',
+  'timer.vala',
+  'timer-action-group.vala',
+  'timer-state.vala',
+  'utils.vala',
+  'window.vala',
+  gnome_pomodoro_generated_sources,
+]
+
+libgnome_pomodoro = shared_library(
+  'gnome-pomodoro',
+  libgnome_pomodoro_vala_sources,
+  dependencies: [
+    gio_dep,
+    gobject_dep,
+    gom_dep,
+    gtk_dep,
+    libm_dep,
+    peas_dep,
+    sqlite_dep,
+  ],
+  # include config.h
+  include_directories: incs,
+  version: '0.0.0',
+  install: true,
+)
+
+gnome_pomodoro_lib_dep = declare_dependency(
+  link_with: libgnome_pomodoro,
+  dependencies: [
+    gio_dep,
+    gobject_dep,
+    peas_dep,
+    gtk_dep,
+  ],
+  include_directories: [
+    # Include gnome-pomodoro.h
+    include_directories('.'),
+    # Include config.h
+    include_directories('..'),
+  ],
+)

--- a/meson-post-install.sh
+++ b/meson-post-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+prefix="${MESON_INSTALL_PREFIX}"
+datadir="${prefix}/$1"
+
+# Distro packagers define DESTDIR and they don't
+# want/need us to do the below
+if [[ -z $DESTDIR ]]; then
+    echo "Compiling GSchema..."
+    glib-compile-schemas $datadir"/glib-2.0/schemas"
+
+    echo "Updating icon cache..."
+    gtk-update-icon-cache -f -t $datadir"/icons/hicolor"
+
+    echo "Updating desktop database..."
+    update-desktop-database -q $datadir"/applications"
+fi

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,138 @@
+project(
+  'gnome-pomodoro',
+  ['vala', 'c'],
+  version: '0.18.1',
+  meson_version: '>=0.49.0',
+)
+
+i18n = import('i18n')
+gnome = import ('gnome')
+
+glib_dep = dependency('glib-2.0', version: '>=2.38.0')
+gobject_dep = dependency('gobject-2.0', version: '>=2.38.0')
+gio_dep = dependency('gio-2.0', version: '>=2.38.0')
+gtk_dep = dependency('gtk+-3.0', version: '>=3.20.0')
+gdk_dep = dependency('gdk-pixbuf-2.0')
+introspection_dep = dependency('gobject-introspection-1.0', version: '>=0.10.1')
+peas_dep = dependency('libpeas-1.0', version: '>=1.5.0')
+gom_dep = dependency('gom-1.0', version: '>=0.3.0')
+gstreamer_dep = dependency('gstreamer-1.0', version: '>=1.0.10')
+libcanberra_dep = dependency('libcanberra', version: '>=0.30')
+sqlite_dep = dependency('sqlite3')
+
+cc = meson.get_compiler('c')
+libm_dep = cc.find_library('m')
+valac = meson.get_compiler('vala')
+posix_dep = valac.find_library('posix')
+
+add_project_arguments(
+  [
+    '--vapidir', meson.current_source_dir(),
+    '--vapidir', meson.current_source_dir() / 'vapi',
+    '--pkg', 'config',
+  ],
+  language: 'vala',
+)
+
+add_project_arguments(
+  '-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
+  language: 'c',
+)
+
+# We are going to use these variables later on for the plugins
+gschema_dir = get_option('prefix') / get_option('datadir') / 'glib-2.0' / 'schemas'
+plugin_libdir = get_option('prefix') / get_option('libdir') / meson.project_name() / 'plugins'
+extension_dir = get_option('prefix') / get_option('datadir') / 'gnome-shell' / 'extensions' / 'pomodoro@arun.codito.in'
+
+# TODO: Remove the double quotes from plugins/indicator/extension/config.js.in.
+# Right now we have to set the below config values twice because of that,
+# the C/Vala code needs these to be quoted (done via `set_quoted`), but
+# config.js.in needs them to be unquoted
+package_name = meson.project_name()
+package_datadir = get_option('prefix') / get_option('datadir') / meson.project_name()
+package_string = package_name + ' ' + meson.project_version()
+package_version = meson.project_version()
+package_bugreport = 'https://github.com/codito/gnome-pomodoro/issues'
+package_url = 'http://gnomepomodoro.org'
+gettext_package = package_name
+extension_uuid = 'pomodoro@arun.codito.in'
+package_localedir = get_option('prefix') / get_option('datadir') / 'locale'
+
+conf = configuration_data()
+
+conf.set_quoted(
+  'GETTEXT_PACKAGE',
+  gettext_package,
+)
+conf.set_quoted(
+  'GSETTINGS_SCHEMA_DIR',
+  gschema_dir,
+)
+conf.set_quoted(
+  'EXTENSION_UUID',
+  extension_uuid,
+)
+conf.set_quoted(
+  'EXTENSION_DIR',
+  extension_dir,
+)
+conf.set_quoted(
+  'PACKAGE_LOCALE_DIR',
+  package_localedir,
+)
+conf.set_quoted(
+  'PACKAGE_LIB_DIR',
+  get_option('prefix') / get_option('libdir') / 'gnome-pomodoro',
+)
+conf.set_quoted(
+  'PACKAGE_DATA_DIR',
+  package_datadir,
+)
+conf.set_quoted(
+  'PLUGIN_DATA_DIR',
+  package_datadir / 'plugins',
+)
+conf.set_quoted(
+  'PLUGIN_LIB_DIR',
+  plugin_libdir,
+)
+conf.set_quoted(
+  'PACKAGE_NAME',
+  package_name,
+)
+conf.set_quoted(
+  'PACKAGE_STRING',
+  package_string
+)
+conf.set_quoted(
+  'PACKAGE_VERSION',
+  package_version,
+)
+conf.set_quoted(
+  'PACKAGE_URL',
+  package_url,
+)
+conf.set_quoted(
+  'PACKAGE_BUGREPORT',
+  package_bugreport,
+)
+
+configure_file(
+  output: 'config.h',
+  configuration: conf,
+)
+
+# Include the config.h we just generated
+incs = include_directories('.')
+
+subdir('data')
+subdir('lib')
+subdir('plugins')
+subdir('po')
+subdir('src')
+subdir('tests')
+
+meson.add_install_script(
+  'meson-post-install.sh',
+  get_option('datadir'),
+)

--- a/plugins/actions/meson.build
+++ b/plugins/actions/meson.build
@@ -1,0 +1,33 @@
+libaction_vala_sources = [
+  'action-listboxrow.vala',
+  'action-page.vala',
+  'actions.vala',
+  'action.vala',
+  'enums.vala',
+  'preferences-page.vala',
+]
+
+generated_sources = gnome.compile_resources(
+  'plugins-actions-resources',
+  'resources/resources.xml',
+  c_name: 'pomodoro',
+  source_dir: 'resources',
+)
+
+shared_library(
+  'actions',
+  [libaction_vala_sources, generated_sources],
+  dependencies: gnome_pomodoro_lib_dep,
+  install: true,
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'actions.plugin',
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'org.gnome.pomodoro.plugins.actions.gschema.xml',
+  install_dir: gschema_dir,
+)

--- a/plugins/builtin/meson.build
+++ b/plugins/builtin/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  'notifications.plugin',
+  install_dir: plugin_libdir,
+)

--- a/plugins/dark-theme/meson.build
+++ b/plugins/dark-theme/meson.build
@@ -1,0 +1,16 @@
+libdark_theme_vala_sources = [
+  'dark-theme-plugin.vala',
+]
+
+shared_library(
+  'dark-theme',
+  libdark_theme_vala_sources,
+  dependencies: gnome_pomodoro_lib_dep,
+  install: true,
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'dark-theme.plugin',
+  install_dir: plugin_libdir,
+)

--- a/plugins/gnome/extension/meson.build
+++ b/plugins/gnome/extension/meson.build
@@ -1,0 +1,71 @@
+extension_files = [
+  'capabilities.js',
+  'dbus.js',
+  'dialogs.js',
+  'extension.js',
+  'indicator.js',
+  'notifications.js',
+  'presence.js',
+  'settings.js',
+  'stylesheet.css',
+  'timer.js',
+  'utils.js',
+]
+
+install_data(
+  extension_files,
+  install_dir: extension_dir,
+)
+
+js_conf = configuration_data()
+
+js_conf.set(
+  'PACKAGE_NAME',
+  package_name,
+)
+js_conf.set(
+  'PACKAGE_STRING',
+  package_string,
+)
+js_conf.set(
+  'PACKAGE_VERSION',
+  package_version,
+)
+js_conf.set(
+  'PACKAGE_BUGREPORT',
+  package_bugreport,
+)
+js_conf.set(
+  'PACKAGE_URL',
+  package_url,
+)
+js_conf.set(
+  'PACKAGE_LOCALE_DIR',
+  package_localedir,
+)
+js_conf.set(
+  'GETTEXT_PACKAGE',
+  gettext_package,
+)
+js_conf.set(
+  'GSETTINGS_SCHEMA_DIR',
+  gschema_dir,
+)
+js_conf.set(
+  'EXTENSION_UUID',
+  extension_uuid,
+)
+
+configure_file(
+  input: 'metadata.json.in',
+  output: 'metadata.json',
+  configuration: js_conf,
+  install_dir: extension_dir,
+)
+
+configure_file(
+  input: 'config.js.in',
+  output: 'config.js',
+  configuration: js_conf,
+  install_dir: extension_dir,
+)

--- a/plugins/gnome/meson.build
+++ b/plugins/gnome/meson.build
@@ -1,0 +1,26 @@
+libgnome_vala_sources = [
+  'gnome.vala',
+  'gnome-idle-monitor.vala',
+  'gnome-plugin.vala',
+  'gnome-shell-extension.vala',
+]
+
+shared_library(
+  'gnome',
+  libgnome_vala_sources,
+  dependencies: gnome_pomodoro_lib_dep,
+  install: true,
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'gnome.plugin',
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'org.gnome.pomodoro.plugins.gnome.gschema.xml',
+  install_dir: gschema_dir,
+)
+
+subdir('extension')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,0 +1,5 @@
+subdir('actions')
+subdir('builtin')
+subdir('dark-theme')
+subdir('gnome')
+subdir('sounds')

--- a/plugins/sounds/meson.build
+++ b/plugins/sounds/meson.build
@@ -1,0 +1,34 @@
+libsound_vala_sources = [
+  'sound-player.vala',
+  'sounds-plugin.vala',
+]
+
+generated_sources = gnome.compile_resources(
+  'plugins-sounds-resources',
+  'resources/resources.xml',
+  c_name: 'pomodoro',
+  source_dir: 'resources',
+)
+
+shared_library(
+  'sounds',
+  [libsound_vala_sources, generated_sources],
+  dependencies: [
+    gnome_pomodoro_lib_dep,
+    gstreamer_dep,
+    libcanberra_dep,
+    libm_dep,
+  ],
+  install: true,
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'sounds.plugin',
+  install_dir: plugin_libdir,
+)
+
+install_data(
+  'org.gnome.pomodoro.plugins.sounds.gschema.xml',
+  install_dir: gschema_dir,
+)

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,5 @@
+i18n.gettext(
+  gettext_package,
+  install: true,
+  preset: 'glib',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,14 @@
+gnome_pomodoro_vala_sources = [
+  'main.vala',
+]
+
+executable(
+  'gnome-pomodoro',
+  gnome_pomodoro_vala_sources,
+  dependencies: [
+    gnome_pomodoro_lib_dep,
+    posix_dep,
+  ],
+  include_directories: incs,
+  install: true,
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,19 @@
+gnome_pomodoro_test_vala_sources = [
+  'tests.vala',
+  'test-application.vala',
+  'test-capability.vala',
+  'test-capability-group.vala',
+  'test-capability-manager.vala',
+  'test-timer.vala',
+]
+
+test_executable = executable(
+  'gnome-pomodoro-test-executable',
+  gnome_pomodoro_test_vala_sources,
+  dependencies: gnome_pomodoro_lib_dep,
+)
+
+test(
+  'gnome-pomodoro-tests',
+  test_executable,
+)


### PR DESCRIPTION
This PR ports gnome-pomodoro to meson. This already installs everything correctly (as far as my initial testing is concerned), but certainly isn't optimal in terms of style. Also, I didn't implement options yet. I'll be pushing some more commits which add comments etc. soon, but feel free to take a look at it already.

A few things I noticed:
* `config.js.in` in `./plugins/gnome/extension` quotes its macros with double quotes, which is kind of annoying with meson. That is because (almost) all values which are in the `config.h` header have to be quoted (which is done via  the `set_quoted` function in meson), but the ones for the js file have to be unquoted. This means that we currently have to define the same things twice, once quoted and once unquoted. Would it be possible to remove the double quotes from config.js.in?
* I had to symlink `./config.vapi` to `./vapi/config.vapi`, so that vala picks up both `config.vapi` and `gom-1.0.vapi` in `./vapi` via `--vapidir`. I don't know vala _that_ well though, so maybe this is unecessary.
* Apparently autotools doesn't translate `org.gnome.Pomodoro.appdata.xml`. I guess this is a bug in the autotools build system and not wanted behavior, so meson currently translates it.
* Should meson automatically re-generate gtk-icon-cache and gschemas on install?

A few things to note when reviewing this:
* I tried to keep the meson files rather simple. I tried to achieve this by not using variables excessively and instead doing some things twice (e.g. using `join_paths(get_option('prefix'), get_option('datadir'))` multiple times in a file instead of using a variable for that (e.g. `datadir = join_paths(get_option('prefix'), get_option('datadir'))`). While this does "bloat" the meson files a little I feel like it makes them easier to understand, as someone who didn't work with gnome-pomodoro's build system would have to go through all the variables first otherwise.
* This currently needs `meson >=0.46.0`, which is the latest version of meson. I use `both_libraries` to generate shared and static libraries in one function, which is more elegant and also builds faster, since meson can re-use the object code it builds and just links it differently instead of building it twice like it'd have to when using both `shared_library` and `static_library`. However, I expected that most distros will have meson 0.46.0 in their repos soon(-ish).
* I like to use fixup commits in Github PRs, since Github PRs sadly don't show what changed between pushes like Gitlab MRs do. Please __DO NOT__ merge this PR as long as there are still fixup commits (ones in the format of `fixup! <commit-msg>`) in it, as this means that it's not ready to be merged yet (and it'd make for quite an ugly git history in `master`).

Fixes #351 