### PR TITLE
Use add_seconds when pausing to lower cpu usage.

### DIFF
--- a/lib/timer.vala
+++ b/lib/timer.vala
@@ -260,7 +260,7 @@ namespace Pomodoro
         private void start_timeout ()
         {
             if (this.timeout_source == 0) {
-                this.timeout_source = GLib.Timeout.add (1000, this.on_timeout);
+                this.timeout_source = GLib.Timeout.add_seconds (1, this.on_timeout);
             }
         }
 


### PR DESCRIPTION
This is a 1st tentative to solve the issue seen in #388 and #379 I believe.
Rationale:
* `Glib.Timeout.add` uses under the hood [g-timeout-add](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-timeout-add) which clearly states: `If you want to have a timer in the "seconds" range and do not care about the exact time of the first call of the timer, use the g_timeout_add_seconds() function; this function allows for more optimizations and more efficient system power usage.`
* The interval of `Glib.Timeout.add` is milliseconds and you're using `1000` as a value so 1 second
* as described in https://valadoc.org/glib-2.0/GLib.Timeout.add_seconds_full.html `If your timer is in multiples of seconds and you don't require the first timer exactly one second from now, the use of g_timeout_add_seconds is preferred over g_timeout_add.`

Note: If you look at the output of `strace -f gnome-pomodoro` it seems that the timeout is done way more than it should and there's way more activity than it should. I wonder if the doc is really accurate when it says the interval of g_timeout_add is in milliseconds.