### PR TITLE
Lower the cpu usage of the animation when on pause.

### DIFF
--- a/lib/animation.vala
+++ b/lib/animation.vala
@@ -87,24 +87,7 @@ namespace Pomodoro
 
             this.target.get_property (this.property_name, ref begin_value);
 
-            this.value_from = begin_value.get_double ();
-            this.func       = Animation.get_func (mode);
-            this.timestamp  = GLib.get_real_time () / 1000;
-
-            if (this.timeout_id != 0) {
-                GLib.Source.remove (this.timeout_id);
-                this.timeout_id = 0;
-            }
-
-            if (this.duration > 0 && this.value_from != this.value_to) {
-                this.timeout_id = GLib.Timeout.add (
-                                    uint.min (1000 / this.frames_per_second, this.duration),
-                                    (GLib.SourceFunc) this.on_timeout);
-                this.progress   = 0.0;
-            }
-            else {
-                this.progress   = 1.0;
-            }
+            this.start_with_value (begin_value.get_double ());
         }
 
         // TODO: it's so hackish...
@@ -112,7 +95,7 @@ namespace Pomodoro
         {
             this.value_from = value_from;
             this.func       = Animation.get_func (mode);
-            this.timestamp  = GLib.get_real_time () / 1000;
+            this.timestamp  = GLib.get_monotonic_time () / 1000;
 
             if (this.timeout_id != 0) {
                 GLib.Source.remove (this.timeout_id);
@@ -147,7 +130,7 @@ namespace Pomodoro
 
         private bool on_timeout ()
         {
-            var current_timestamp = GLib.get_real_time () / 1000;
+            var current_timestamp = GLib.get_monotonic_time () / 1000;
 
             this.progress  = (this.duration > 0)
                 ? ((double)(current_timestamp - this.timestamp) / this.duration).clamp (0.0, 1.0)

--- a/lib/window.vala
+++ b/lib/window.vala
@@ -184,7 +184,7 @@ namespace Pomodoro
 
                 this.blink_animation = new Pomodoro.Animation (Pomodoro.AnimationMode.BLINK,
                                                                2500,
-                                                               25);
+                                                               5);
                 this.blink_animation.add_property (this.timer_box,
                                                    "opacity",
                                                    FADED_OUT);


### PR DESCRIPTION
The main change is changing the call of the on_timeout that verifies the progress from every `1000/25 = 40ms` to `1000/5 = 200ms`.
Also included:
* switch from `GLib.get_real_time` to `GLib.get_monotonic_time` as recommended  on https://valadoc.org/glib-2.0/GLib.get_real_time.html
* remove duplicate code (the main content of `start` is what's in `start_with_value`)

Based on the test I've done on i3 it does have a significant impact on the CPU usage when on pause. But full disclaimer I didn't have a 100% CPU usage as described by @qwrtln in #388 or by @mdmahendri in #379 (Merely 1 CPU at 30% but that's on a pretty powerful laptop).

If you guys could try the patch with gnome, that would be great, thanks!

@kamilprusko does that seem a reasonable change to you? I don't really see the difference in terms of fading to be honest with i3 right now.