### PR TITLE
Add Gnome 41 support

### DIFF
--- a/plugins/gnome/extension/metadata.json.in
+++ b/plugins/gnome/extension/metadata.json.in
@@ -2,7 +2,7 @@
   "uuid": "@EXTENSION_UUID@",
   "name": "Pomodoro",
   "description": "Desktop integration for Pomodoro application.",
-  "shell-version": ["3.38", "40.0"],
+  "shell-version": ["3.38", "40.0", "41.0"],
   "url": "@PACKAGE_URL@",
   "version": "@PACKAGE_VERSION@"
 }


### PR DESCRIPTION
## Pull request checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Shell extension does not load on Gnome 41 (Testing on Fedora 35)

## What is the new behavior?

Shell extension works normally on Gnome 41 (Testing on Fedora 35)
