### PR TITLE
Avoid use of deprecated GtkWidget properties

### DIFF
--- a/data/resources/preferences-keyboard-shortcut-page.ui
+++ b/data/resources/preferences-keyboard-shortcut-page.ui
@@ -5,8 +5,8 @@
   <template class="PomodoroPreferencesKeyboardShortcutPage" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">30</property>
-    <property name="margin_right">30</property>
+    <property name="margin_start">30</property>
+    <property name="margin_end">30</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
     <property name="border_width">12</property>
@@ -16,8 +16,8 @@
       <object class="GtkBox" id="chooser_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">12</property>
-        <property name="margin_right">12</property>
+        <property name="margin_start">12</property>
+        <property name="margin_end">12</property>
         <property name="margin_top">12</property>
         <property name="margin_bottom">12</property>
         <property name="orientation">vertical</property>

--- a/data/resources/preferences-main-page.ui
+++ b/data/resources/preferences-main-page.ui
@@ -22,8 +22,8 @@
           <object class="GtkBox" id="box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">30</property>
-            <property name="margin_right">30</property>
+            <property name="margin_start">30</property>
+            <property name="margin_end">30</property>
             <property name="margin_top">12</property>
             <property name="margin_bottom">12</property>
             <property name="border_width">12</property>
@@ -39,8 +39,8 @@
                   <object class="GtkLabel" id="timer_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
-                    <property name="margin_right">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <property name="margin_bottom">6</property>
                     <property name="label" translatable="yes">Timer</property>
                     <property name="xalign">0</property>
@@ -86,7 +86,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_right">5</property>
+                                    <property name="margin_end">5</property>
                                     <property name="label">25 minutes</property>
                                     <style>
                                       <class name="dim-label"/>
@@ -103,7 +103,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_left">5</property>
+                                    <property name="margin_start">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="label" translatable="yes">Pomodoro duration</property>
                                   </object>
@@ -138,7 +138,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_right">5</property>
+                                    <property name="margin_end">5</property>
                                     <property name="label">5 minutes</property>
                                     <style>
                                       <class name="dim-label"/>
@@ -155,7 +155,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_left">5</property>
+                                    <property name="margin_start">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="label" translatable="yes">Break duration</property>
                                   </object>
@@ -191,7 +191,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_right">5</property>
+                                    <property name="margin_end">5</property>
                                     <property name="label">15 minutes</property>
                                     <style>
                                       <class name="dim-label"/>
@@ -208,7 +208,7 @@
                                     <property name="can_focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="valign">baseline</property>
-                                    <property name="margin_left">5</property>
+                                    <property name="margin_start">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="label" translatable="yes">Long break duration</property>
                                   </object>
@@ -351,8 +351,8 @@
                   <object class="GtkLabel" id="notifications_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
-                    <property name="margin_right">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <property name="margin_bottom">6</property>
                     <property name="label" translatable="yes">Notifications</property>
                     <property name="xalign">0</property>
@@ -454,8 +454,8 @@
                   <object class="GtkLabel" id="desktop_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
-                    <property name="margin_right">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <property name="margin_bottom">6</property>
                     <property name="label" translatable="yes">Desktop</property>
                     <property name="xalign">0</property>

--- a/data/resources/preferences-plugins-page.ui
+++ b/data/resources/preferences-plugins-page.ui
@@ -14,8 +14,8 @@
           <object class="GtkBox" id="box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">30</property>
-            <property name="margin_right">30</property>
+            <property name="margin_start">30</property>
+            <property name="margin_end">30</property>
             <property name="margin_top">12</property>
             <property name="margin_bottom">12</property>
             <property name="border_width">12</property>

--- a/data/resources/stats-view.ui
+++ b/data/resources/stats-view.ui
@@ -148,8 +148,8 @@
               <object class="GtkBox" id="navigation">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
+                <property name="margin_start">10</property>
+                <property name="margin_end">10</property>
                 <property name="margin_top">10</property>
                 <property name="margin_bottom">10</property>
                 <property name="vexpand">False</property>

--- a/data/resources/window.ui
+++ b/data/resources/window.ui
@@ -59,8 +59,8 @@
               <object class="GtkStack" id="timer_stack">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">20</property>
-                <property name="margin_right">20</property>
+                <property name="margin_start">20</property>
+                <property name="margin_end">20</property>
                 <property name="margin_top">50</property>
                 <property name="margin_bottom">50</property>
                 <property name="transition_type">crossfade</property>
@@ -80,8 +80,8 @@
                       <object class="GtkImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">50</property>
-                        <property name="margin_right">50</property>
+                        <property name="margin_start">50</property>
+                        <property name="margin_end">50</property>
                         <property name="margin_top">50</property>
                         <property name="margin_bottom">50</property>
                         <property name="pixel_size">64</property>
@@ -293,8 +293,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">10</property>
-        <property name="margin_right">10</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
         <property name="margin_top">10</property>
         <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>
@@ -364,8 +364,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">10</property>
-        <property name="margin_right">10</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
         <property name="margin_top">10</property>
         <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>

--- a/plugins/actions/resources/action-page.ui
+++ b/plugins/actions/resources/action-page.ui
@@ -5,8 +5,8 @@
   <template class="ActionsActionPage" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">30</property>
-    <property name="margin_right">30</property>
+    <property name="margin_start">30</property>
+    <property name="margin_end">30</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">24</property>
     <property name="orientation">vertical</property>
@@ -294,8 +294,8 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">10</property>
-                    <property name="margin_right">10</property>
+                    <property name="margin_start">10</property>
+                    <property name="margin_end">10</property>
                     <property name="label" translatable="yes">Add</property>
                   </object>
                 </child>

--- a/plugins/actions/resources/preferences-page.ui
+++ b/plugins/actions/resources/preferences-page.ui
@@ -23,8 +23,8 @@
               <object class="GtkFrame">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">30</property>
-                <property name="margin_right">30</property>
+                <property name="margin_start">30</property>
+                <property name="margin_end">30</property>
                 <property name="margin_top">12</property>
                 <property name="margin_bottom">12</property>
                 <property name="border_width">12</property>

--- a/plugins/sounds/resources/preferences-sound-page.ui
+++ b/plugins/sounds/resources/preferences-sound-page.ui
@@ -8,8 +8,8 @@
   <template class="SoundsPluginPreferencesSoundPage" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">30</property>
-    <property name="margin_right">30</property>
+    <property name="margin_start">30</property>
+    <property name="margin_end">30</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">24</property>
     <property name="border_width">12</property>
@@ -19,8 +19,8 @@
       <object class="GtkBox" id="volume_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_bottom">24</property>
         <child>
           <object class="GtkLabel" id="volume_label">
@@ -28,7 +28,7 @@
             <property name="can_focus">False</property>
             <property name="halign">start</property>
             <property name="valign">baseline</property>
-            <property name="margin_right">32</property>
+            <property name="margin_end">32</property>
             <property name="hexpand">False</property>
             <property name="label" translatable="yes">Volume:</property>
           </object>


### PR DESCRIPTION
GtkWidget:margin-left and GtkWidget:margin-right have been
deprecated since GTK 3.12 and are removed from GTK 4

## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Deprecation warnings observed in the console:
```
(gnome-pomodoro:3323231): GLib-GObject-WARNING **: 14:44:53.706: The property GtkWidget:margin-left is deprecated and shouldn't be used anymore. It will be removed in a future version.

(gnome-pomodoro:3323231): GLib-GObject-WARNING **: 14:44:53.706: The property GtkWidget:margin-right is deprecated and shouldn't be used anymore. It will be removed in a future version.
```

## What is the new behavior?

No more GtkWidget property deprecation notices :-)

## Other information

Fixing usages of deprecated APIs will make future migration to GTK 4 a lot easier.

Note: Oops this a second PR. I accidentally closed the original PR for this change because it wasn't on a feature branch... Doh