### PR TITLE
Fixes #556 Stats page doesn't open from shell extension

### DIFF
--- a/plugins/gnome/extension/timer.js
+++ b/plugins/gnome/extension/timer.js
@@ -227,8 +227,8 @@ var Timer = class {
         return state === State.SHORT_BREAK || state === State.LONG_BREAK;
     }
 
-    showMainWindow(timestamp) {
-        this._proxy.ShowMainWindowRemote(timestamp, this._onCallback.bind(this));
+    showMainWindow(mode, timestamp) {
+        this._proxy.ShowMainWindowRemote(mode, timestamp, this._onCallback.bind(this));
     }
 
     showPreferences(timestamp) {


### PR DESCRIPTION
This change fixes missing argument in ShowMainWindow that was causing
JS ERROR: Error: Argument value: value is out of range for uint32

## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

See Issue Number: #556 

Nothing happens when opening stats from the shell extension (just a JS error in the log)

## What is the new behavior?

Stats page opens successfully
