### PR TITLE
Fix GNOME extension error reporting

### DIFF
--- a/plugins/gnome/extension/extension.js
+++ b/plugins/gnome/extension/extension.js
@@ -95,7 +95,7 @@ var PomodoroExtension = class {
             this.setMode(mode);
         }
         catch (error) {
-            Utils.logError(error.message);
+            Utils.logError(error);
         }
     }
 
@@ -184,7 +184,7 @@ var PomodoroExtension = class {
     _onServiceNameLost() {
         this.emit('service-name-lost');
 
-        Utils.logError('Lost service name "org.gnome.Pomodoro.Extension"');
+        Utils.logError(new Errror('Lost service name "org.gnome.Pomodoro.Extension"'));
     }
 
     _onTimerServiceConnected() {
@@ -403,7 +403,7 @@ var PomodoroExtension = class {
                 Main.panel.addToStatusArea(Config.PACKAGE_NAME, this.indicator);
             }
             catch (error) {
-                Utils.logError(error.message);
+                Utils.logError(error);
             }
         }
         else {

--- a/plugins/gnome/extension/utils.js
+++ b/plugins/gnome/extension/utils.js
@@ -23,7 +23,6 @@ const Signals = imports.signals;
 const Shell = imports.gi.Shell;
 
 const Main = imports.ui.main;
-const ExtensionSystem = imports.ui.extensionSystem;
 
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 
@@ -227,8 +226,8 @@ function getFocusedWindowInfo() {
 }
 
 
-function logError(message) {
-    ExtensionSystem.logExtensionError(Extension.metadata.uuid, message);
+function logError(error) {
+    Main.extensionManager.logExtensionError(Extension.metadata.uuid, error);
 }
 
 


### PR DESCRIPTION
GNOME Shell 3.33 changed the internal API for logging extension errors so when an error occurred, it was obscured by https://gitlab.gnome.org/GNOME/gnome-shell/commit/ea177407191c17e6e386e5b36bad2508c8cbcdcb

Additionally, the function was changed to only accept Error objects: https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/c99e8eb29d4dea22026d2e0545060353edc9f773

## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes: https://github.com/gnome-pomodoro/gnome-pomodoro/issues/446
Fixes: https://github.com/gnome-pomodoro/gnome-pomodoro/issues/560

## What is the new behavior?

Extension no longer crashes when it encounters an error.

## Other information

(Write your answer here.)
