### PR TITLE
Support GNOME Shell 42 in Shell extension

### DIFF
--- a/plugins/gnome/extension/dialogs.js
+++ b/plugins/gnome/extension/dialogs.js
@@ -46,7 +46,7 @@ const ngettext = Gettext.ngettext;
  */
 const IDLE_TIME_TO_PUSH_MODAL = 600;
 const PUSH_MODAL_TIME_LIMIT = 1000;
-const PUSH_MODAL_RATE = Clutter.get_default_frame_rate();
+const PUSH_MODAL_RATE = 60;
 const MOTION_DISTANCE_TO_CLOSE = 20;
 
 const IDLE_TIME_TO_OPEN = 60000;

--- a/plugins/gnome/extension/metadata.json.in
+++ b/plugins/gnome/extension/metadata.json.in
@@ -2,7 +2,7 @@
   "uuid": "@EXTENSION_UUID@",
   "name": "Pomodoro",
   "description": "Desktop integration for Pomodoro application.",
-  "shell-version": ["3.38", "40", "41"],
+  "shell-version": ["3.38", "40", "41", "42"],
   "url": "@PACKAGE_URL@",
   "version": "@PACKAGE_VERSION@"
 }


### PR DESCRIPTION
Clutter.get_default_frame_rate() was removed in
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2002/diffs?commit_id=33cdb45c8fdd9aa6f6da334a139a4a0fd1afe361

It effectively was always equal to 60, so let's hardcode the value.

Fixes  #608.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

See #608.