### PR TITLE
Fix GNOME detection

### DIFF
--- a/plugins/gnome/gnome-plugin.vala
+++ b/plugins/gnome/gnome-plugin.vala
@@ -153,7 +153,7 @@ namespace GnomePlugin
                                       GLib.Cancellable? cancellable = null)
                                       throws GLib.Error
         {
-            this.is_gnome = GLib.Environment.get_variable (CURRENT_DESKTOP_VARIABLE) == "GNOME";
+            this.is_gnome = GLib.Environment.get_variable (CURRENT_DESKTOP_VARIABLE).has_suffix ("GNOME");
             this.settings = Pomodoro.get_settings ().get_child ("preferences");
             this.capabilities = new Pomodoro.CapabilityGroup ("gnome");
 


### PR DESCRIPTION
Depending on the distribution, XDG_CURRENT_DESKTOP may just end with
"GNOME", e.g., "ubuntu:GNOME".

Fixes #620.