### PR TITLE
Fix break overlay stuck when pushModal failed

### DIFF
--- a/plugins/gnome/extension/dialogs.js
+++ b/plugins/gnome/extension/dialogs.js
@@ -474,6 +474,10 @@ var ModalDialog = GObject.registerClass({
                 Main.popModal(grab);
                 return false;
             }
+        } else {
+            if (!grab) {
+                return false;
+            }
         }
 
         this._grab = grab;


### PR DESCRIPTION
When pomodoro extension calls pushModal it may fails.
Currently, it will set _hasModal to true nevertheless.
Thus popModal will no be aborted and an exception is raised when it is
called and adhoc pushModal previously failed.

Exit pomodoro pushModal before setting _hasModal to true when
Main.pushModal failed.

Here (gnome-shell 3.38.6) when pushModal fails with this fix pushModal
will be called and ends up succeeding.

This guard only affect gnome-shell pre 42.

Related to issue 604. Though my fix only y affects gnome-shell pre 42 and I don't know if the issuers were all below 42 (though Fedora 34 is shipped with gnome-shell 40).

## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

I cannot find how to setup eslint-plugin-jsdoc required by eslint-gjs.yml. Could you explain the steps to install the linter ?

## Pull request type

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Can't quit break screen when pushModal failed.
Issue Number: 604

## What is the new behavior?
Overlay close and free the grab when I move the mouse or press a key..

## Other information

The issue likely is gnome-shell pre 42 only.