### PR TITLE
Mark extension as compatible with gnome-shell 43

### DIFF
--- a/plugins/gnome/extension/metadata.json.in
+++ b/plugins/gnome/extension/metadata.json.in
@@ -2,7 +2,7 @@
   "uuid": "@EXTENSION_UUID@",
   "name": "Pomodoro",
   "description": "Desktop integration for Pomodoro application.",
-  "shell-version": ["3.38", "40", "41", "42"],
+  "shell-version": ["3.38", "40", "41", "42", "43"],
   "url": "@PACKAGE_URL@",
   "version": "@PACKAGE_VERSION@"
 }


### PR DESCRIPTION
The extension appears to be compatible with gnome-shell 43.Beta as packaged in Debian experimental.

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):