### PR TITLE
Install scalable SVG icon

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -17,6 +17,11 @@ foreach i:icon_dirs
 endforeach
 
 install_data(
+    'scalable' / 'gnome-pomodoro.svg',
+    install_dir: hicolor_icondir / 'scalable' / 'apps',
+)
+
+install_data(
     'symbolic' / 'gnome-pomodoro-symbolic.svg',
     install_dir: hicolor_icondir / 'symbolic' / 'apps',
 )

--- a/data/icons/scalable/gnome-pomodoro.svg
+++ b/data/icons/scalable/gnome-pomodoro.svg
@@ -1,0 +1,2246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="242.3286"
+   height="246.03725"
+   id="svg11300"
+   version="1.0"
+   style="enable-background:new"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title13909">Evolution</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient8983">
+      <stop
+         id="stop8979"
+         offset="0"
+         style="stop-color:#f0f0f0;stop-opacity:1" />
+      <stop
+         id="stop8981"
+         offset="1"
+         style="stop-color:#bdbdbd;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4341">
+      <stop
+         id="stop4343"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.84313726;" />
+      <stop
+         id="stop4345"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.36601308;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4306">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4308" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.65359479;"
+         offset="1"
+         id="stop4310" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4293">
+      <stop
+         style="stop-color:#d9dbd7;stop-opacity:1;"
+         offset="0"
+         id="stop4295" />
+      <stop
+         style="stop-color:#b1b2af;stop-opacity:1;"
+         offset="1"
+         id="stop4297" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4525">
+      <stop
+         style="stop-color:#d9dbd7;stop-opacity:1;"
+         offset="0"
+         id="stop4527" />
+      <stop
+         style="stop-color:#b1b2af;stop-opacity:1;"
+         offset="1"
+         id="stop4529" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4203">
+      <stop
+         style="stop-color:#eeeeed;stop-opacity:1;"
+         offset="0"
+         id="stop4205" />
+      <stop
+         style="stop-color:#e0e0de;stop-opacity:1;"
+         offset="1"
+         id="stop4207" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5210">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.56521738;"
+         offset="0"
+         id="stop5212" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5214" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4818">
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1;"
+         offset="0"
+         id="stop4820" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:0;"
+         offset="1"
+         id="stop4822" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4522">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+      <stop
+         id="stop4530"
+         offset="0.70866144"
+         style="stop-color:#f3f3f2;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2e2df;stop-opacity:1;"
+         offset="1"
+         id="stop4526" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4516">
+      <stop
+         id="stop4518"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4520"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4449">
+      <stop
+         style="stop-color:#777777;stop-opacity:1;"
+         offset="0"
+         id="stop4451" />
+      <stop
+         style="stop-color:#777777;stop-opacity:0;"
+         offset="1"
+         id="stop4453" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4439">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4441" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4443" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4401">
+      <stop
+         id="stop4403"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.875;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.29891303;"
+         offset="0.40944883"
+         id="stop4405" />
+      <stop
+         id="stop4407"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.46195653;"
+         offset="0"
+         id="stop4389" />
+      <stop
+         id="stop4395"
+         offset="0.67716533"
+         style="stop-color:#000000;stop-opacity:0.11413044;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4391" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11359">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop11361" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11363" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11349">
+      <stop
+         style="stop-color:#a3a3a3;stop-opacity:1"
+         offset="0"
+         id="stop11351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1"
+         id="stop11353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11257">
+      <stop
+         id="stop11259"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.27692308" />
+      <stop
+         id="stop11261"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11225">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop11227" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11229" />
+    </linearGradient>
+    <linearGradient
+       y2="1.311599"
+       x2="88.372581"
+       y1="238"
+       x1="170.34314"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6013"
+       xlink:href="#linearGradient10053" />
+    <linearGradient
+       id="linearGradient10053">
+      <stop
+         id="stop10055"
+         offset="0"
+         style="stop-color:#f6f6f5;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.19354598"
+         id="stop5355" />
+      <stop
+         id="stop10057"
+         offset="1"
+         style="stop-color:#eeeeec;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3873">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3875" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3877" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3791">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3793" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3795" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3851">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3853" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3855" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3751">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3753" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3755" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3751"
+       id="linearGradient10948"
+       gradientUnits="userSpaceOnUse"
+       x1="-393.5"
+       y1="53.754749"
+       x2="-393.5"
+       y2="-74.509018" />
+    <linearGradient
+       xlink:href="#linearGradient3851"
+       id="linearGradient10956"
+       gradientUnits="userSpaceOnUse"
+       x1="-372.5"
+       y1="188.8755"
+       x2="-372.5"
+       y2="129.75" />
+    <linearGradient
+       xlink:href="#linearGradient3791"
+       id="linearGradient10958"
+       gradientUnits="userSpaceOnUse"
+       x1="-324"
+       y1="-17.50746"
+       x2="-324"
+       y2="49.516186" />
+    <linearGradient
+       xlink:href="#linearGradient3873"
+       id="linearGradient10964"
+       gradientUnits="userSpaceOnUse"
+       x1="-445.5"
+       y1="237.42877"
+       x2="-445.5"
+       y2="256.75098" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient10966"
+       gradientUnits="userSpaceOnUse"
+       x1="-393"
+       y1="153"
+       x2="-336"
+       y2="242" />
+    <linearGradient
+       id="linearGradient2152">
+      <stop
+         style="stop-color:#9aa29a;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2154" />
+      <stop
+         style="stop-color:#b5beb5;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2156" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop10695"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient37935">
+      <stop
+         style="stop-color:#9497b3;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop37937" />
+      <stop
+         style="stop-color:#4c4059;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop37939" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2145">
+      <stop
+         id="stop2147"
+         offset="0.0000000"
+         style="stop-color:#fffffd;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2149"
+         offset="1.0000000"
+         style="stop-color:#cbcbc9;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient42174">
+      <stop
+         id="stop42176"
+         offset="0.0000000"
+         style="stop-color:#a0a0a0;stop-opacity:1.0000000;" />
+      <stop
+         id="stop42178"
+         offset="1.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2111">
+      <stop
+         id="stop2113"
+         offset="0.0000000"
+         style="stop-color:#838383;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2115"
+         offset="1.0000000"
+         style="stop-color:#000000;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10653">
+      <stop
+         id="stop10655"
+         offset="0.0000000"
+         style="stop-color:#f3f4ff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop10657"
+         offset="1.0000000"
+         style="stop-color:#9193af;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15107">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop15109" />
+      <stop
+         style="stop-color:#e2e2e2;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop15111" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2136">
+      <stop
+         style="stop-color:#989690;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2138" />
+      <stop
+         style="stop-color:#656460;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18913">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop18915" />
+      <stop
+         style="stop-color:#c8c8c8;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop18917" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2166">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2168" />
+      <stop
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2170" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9749">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop9751" />
+      <stop
+         style="stop-color:#ededed;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop9753" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2274">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.12871288;"
+         offset="0.0000000"
+         id="stop2276" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.0000000;"
+         offset="1.0000000"
+         id="stop2278" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15193">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e00000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 94.752307,81.344625 139.3126,135.80441 c 5.16383,-5.91155 8.78641,-9.07383 15.98421,-10.56043 10.7493,-2.22011 28.44922,-2.45177 38.90689,1.00771 5.75177,1.90273 9.91484,6.39876 12.66425,9.81344 L 251.02291,80.637518 212.83914,28.311616 135.0574,24.776082 Z"
+         id="path15195" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient0-paper-sheet-orig-1"
+       id="linearGradient15279"
+       gradientUnits="userSpaceOnUse"
+       x1="84"
+       y1="200.5"
+       x2="-104.06974"
+       y2="-127.99076" />
+    <linearGradient
+       id="linearGradient0-paper-sheet-orig-1">
+      <stop
+         id="stop0-paper-sheet-orig-6"
+         offset="0"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 1;" />
+      <stop
+         id="stop1-paper-sheet-orig-5"
+         offset="1"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3-paper-sheet-orig-0-6"
+       id="radialGradient15281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(25.3062,2.17939e-6,-1.07308e-6,12.4602,2199.23,-911.49)"
+       cx="-80.660522"
+       cy="88.982887"
+       fx="-80.660522"
+       fy="88.982887"
+       r="18.000002" />
+    <linearGradient
+       id="linearGradient3-paper-sheet-orig-0-6">
+      <stop
+         id="stop6-paper-sheet-orig-2-3"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop7-paper-sheet-orig-8-4"
+         offset="1"
+         style="stop-color: rgb(211, 215, 207); stop-opacity: 1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient28-paper-sheet-orig-4"
+       id="radialGradient15283"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.59674,-0.285292,0.176907,2.23031,-355.116,-121.578)"
+       cx="128.59172"
+       cy="116.46977"
+       fx="128.59172"
+       fy="116.46977"
+       r="92.902176" />
+    <linearGradient
+       id="linearGradient28-paper-sheet-orig-4">
+      <stop
+         id="stop34-paper-sheet-orig-3"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop35-paper-sheet-orig-7"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath0-paper-sheet-orig-3"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         id="path0-paper-sheet-orig-9"
+         d="m 36,19 c -0.562656,0 -1,0.437344 -1,1 v 217 c 0,0.56266 0.437344,1 1,1 h 184 c 0.56266,0 1,-0.43734 1,-1 V 66 C 221,52.442308 210.14182,40.704328 204.71875,35.28125 199.29568,29.858173 187.5577,19 174,19 Z"
+         style="fill:url(#linearGradient6013) #000000;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    </clipPath>
+    <radialGradient
+       xlink:href="#linearGradient33-paper-sheet-orig-5"
+       id="radialGradient15285"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.74107,-1.87992,0,120.779,-78.8035)"
+       cx="36"
+       cy="45.296875"
+       fx="36"
+       fy="45.296875"
+       r="84.203125" />
+    <linearGradient
+       id="linearGradient33-paper-sheet-orig-5">
+      <stop
+         id="stop46-paper-sheet-orig-9"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop47-paper-sheet-orig-5"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient35-paper-sheet-orig-7"
+       id="radialGradient15287"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.66303,0,0,0.340371,-84.7016,148.57)"
+       cx="127.75"
+       cy="261.27338"
+       fx="127.75"
+       fy="261.27338"
+       r="92.25" />
+    <linearGradient
+       id="linearGradient35-paper-sheet-orig-7">
+      <stop
+         id="stop50-paper-sheet-orig-2"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop51-paper-sheet-orig-1"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient1-paper-sheet-orig-2"
+       id="radialGradient15289"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.0485,-3.87807,0,165.487,13.8549)"
+       cx="20.479548"
+       cy="31.230524"
+       fx="20.479548"
+       fy="31.230524"
+       r="93" />
+    <linearGradient
+       id="linearGradient1-paper-sheet-orig-2">
+      <stop
+         id="stop2-paper-sheet-orig-4"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop3-paper-sheet-orig-9"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient35-paper-sheet-orig-7"
+       id="radialGradient15291"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.57088,0,0,1.11586,-53.057,0.954809)"
+       cx="127.75"
+       cy="236.25"
+       fx="127.75"
+       fy="236.25"
+       r="92.25" />
+    <radialGradient
+       xlink:href="#linearGradient27-paper-sheet-orig-9-1"
+       id="radialGradient15293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.04422,0,0,0.96082,-12.7447,6.34946)"
+       cx="210.95667"
+       cy="38.580303"
+       fx="210.95667"
+       fy="38.580303"
+       r="34.234375" />
+    <linearGradient
+       id="linearGradient27-paper-sheet-orig-9-1">
+      <stop
+         id="stop32-paper-sheet-orig-0-1"
+         offset="0"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 1;" />
+      <stop
+         id="stop33-paper-sheet-orig-2-5"
+         offset="1"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 0;" />
+    </linearGradient>
+    <mask
+       id="mask0-paper-sheet-orig-6-5"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 36,-31 c -0.562656,0 -1,0.437344 -1,1 v 217 c 0,0.56266 0.437344,1 1,1 h 184 c 0.56266,0 1,-0.43734 1,-1 V 16 C 221,2.442308 208.14182,-7.295672 202.71875,-12.71875 197.29568,-18.141827 187.5577,-31 174,-31 Z"
+         id="path1-paper-sheet-orig-9-2" />
+    </mask>
+    <radialGradient
+       xlink:href="#linearGradient29-paper-sheet-orig-1-7"
+       id="radialGradient15295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.98931,0,0.472637)"
+       cx="196.35764"
+       cy="44.213333"
+       fx="196.35764"
+       fy="44.213333"
+       r="23.76296" />
+    <linearGradient
+       id="linearGradient29-paper-sheet-orig-1-7">
+      <stop
+         id="stop36-paper-sheet-orig-8-4"
+         offset="0"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 1;" />
+      <stop
+         id="stop37-paper-sheet-orig-2-7"
+         offset="1"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 0;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient30-paper-sheet-orig-8-5"
+       id="linearGradient15297"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.5,2.52145)"
+       x1="190.97945"
+       y1="52.972717"
+       x2="196.44823"
+       y2="39.563599" />
+    <linearGradient
+       id="linearGradient30-paper-sheet-orig-8-5">
+      <stop
+         id="stop38-paper-sheet-orig-1-4"
+         offset="0"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 1;" />
+      <stop
+         id="stop39-paper-sheet-orig-9-6"
+         offset="1"
+         style="stop-color: rgb(0, 0, 0); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient31-paper-sheet-orig-8-3"
+       id="radialGradient15299"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.44729,0,0,1.44729,-85.751,-21.5289)"
+       cx="190.875"
+       cy="49.25"
+       fx="190.875"
+       fy="49.25"
+       r="23.5" />
+    <linearGradient
+       id="linearGradient31-paper-sheet-orig-8-3">
+      <stop
+         id="stop40-paper-sheet-orig-4-4"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop41-paper-sheet-orig-4-6"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient32-paper-sheet-orig-9-6"
+       id="radialGradient15301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.597198,-0.450905,1.70446,2.25746,-0.540251,29.1578)"
+       cx="192.25"
+       cy="45.75"
+       fx="192.25"
+       fy="45.75"
+       r="23.5" />
+    <linearGradient
+       id="linearGradient32-paper-sheet-orig-9-6">
+      <stop
+         id="stop42-paper-sheet-orig-3-0"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         style="stop-color: rgb(230, 230, 230); stop-opacity: 1;"
+         offset="0.44760558"
+         id="stop43-paper-sheet-orig-9-9" />
+      <stop
+         id="stop44-paper-sheet-orig-1-3"
+         offset="0.81267858"
+         style="stop-color: rgb(203, 203, 203); stop-opacity: 1;" />
+      <stop
+         id="stop45-paper-sheet-orig-5-0"
+         offset="1"
+         style="stop-color: rgb(219, 219, 219); stop-opacity: 1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient34-paper-sheet-orig-3-6"
+       id="radialGradient15303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.11516,0,0,2.92788,-207.435,-53.6174)"
+       cx="186.76546"
+       cy="27.786123"
+       fx="186.76546"
+       fy="27.786123"
+       r="8.9714146" />
+    <linearGradient
+       id="linearGradient34-paper-sheet-orig-3-6">
+      <stop
+         id="stop48-paper-sheet-orig-9-5"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop49-paper-sheet-orig-3-8"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient36-paper-sheet-orig-4-8"
+       id="radialGradient15305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.997333,0.0729916,-0.11677,1.59551,5.19968,-29.5236)"
+       cx="208.68414"
+       cy="39.762138"
+       fx="208.68414"
+       fy="39.762138"
+       r="13.625" />
+    <linearGradient
+       id="linearGradient36-paper-sheet-orig-4-8">
+      <stop
+         id="stop52-paper-sheet-orig-3-3"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop53-paper-sheet-orig-9-1"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3176-0-8"
+       id="linearGradient15307"
+       gradientUnits="userSpaceOnUse"
+       x1="189.2542"
+       y1="23.661938"
+       x2="189.2542"
+       y2="43.888237" />
+    <linearGradient
+       id="linearGradient3176-0-8">
+      <stop
+         id="stop3178-7-8"
+         offset="0"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" />
+      <stop
+         id="stop3180-3-8"
+         offset="1"
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" />
+    </linearGradient>
+    <linearGradient
+       y2="-74.509018"
+       x2="-393.5"
+       y1="53.754749"
+       x1="-393.5"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient15217"
+       xlink:href="#linearGradient3751-7" />
+    <linearGradient
+       id="linearGradient3751-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3753-3" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3755-5" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3737-8">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -322,-132 c -30.11111,0 -36.13403,7.44423 -42.15625,14.875 L -422,-40 V 93.84375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 C -223.86003,98 -222,96.13998 -222,93.84375 V -40 l -57.84375,-77.125 C -285.86598,-124.55577 -291.88885,-132 -322,-132 Z"
+         id="path3739-3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3807-8">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -422,38 c -30.11111,0 -36.13403,7.44423 -42.15625,14.875 L -522,130 v 133.84375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 c 2.29622,0 4.15625,-1.86002 4.15625,-4.15625 V 130 L -379.84375,52.875 C -385.86598,45.444228 -391.88885,38 -422,38 Z"
+         id="path3809-2" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient3699-3"
+       id="linearGradient3705"
+       x1="-112"
+       y1="53"
+       x2="-112"
+       y2="201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(260)" />
+    <linearGradient
+       id="linearGradient3699-3">
+      <stop
+         style="stop-color:#dbded7;stop-opacity:1"
+         offset="0"
+         id="stop3701-4" />
+      <stop
+         id="stop3707-4"
+         offset="0.31756762"
+         style="stop-color:#eeeeec;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3f3f2;stop-opacity:1"
+         offset="0.49662164"
+         id="stop3711-5" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0.7668919"
+         id="stop3709-7" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="1"
+         id="stop3703-7" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3957-2"
+       id="linearGradient3963"
+       x1="-182"
+       y1="189"
+       x2="-169"
+       y2="321"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(260)" />
+    <linearGradient
+       id="linearGradient3957-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3959-9" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="1"
+         id="stop3961-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3937-4"
+       id="linearGradient3943"
+       x1="-212"
+       y1="198.875"
+       x2="-12"
+       y2="198.875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(260)" />
+    <linearGradient
+       id="linearGradient3937-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3939-1" />
+      <stop
+         id="stop3945-7"
+         offset="0.0275"
+         style="stop-color:#eeeeec;stop-opacity:0" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:0"
+         offset="0.97750002"
+         id="stop3947-8" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3941-1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3851-0"
+       id="linearGradient3857-6"
+       x1="-372.5"
+       y1="164.82263"
+       x2="-372.5"
+       y2="129.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3851-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3853-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3855-1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3843-6">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -442,129.75 v 134.09375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 c 2.29622,0 4.15625,-1.86002 4.15625,-4.15625 V 129.75 l -57.84375,71.375 C -305.86599,208.55577 -311.88885,216 -342,216 c -30.11111,0 -36.13403,-7.44423 -42.15625,-14.875 z"
+         id="path3845-8" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient3791-3"
+       id="linearGradient3797-7"
+       x1="-324"
+       y1="-17.50746"
+       x2="-324"
+       y2="49.516186"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-3">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3793-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3795-5" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3783-1">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="M -472,-100.25 V 33.84375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 C -273.86003,38 -272,36.13998 -272,33.84375 V -100.25 l -57.84375,71.375 C -335.86599,-21.44423 -341.88885,-14 -372,-14 c -30.11111,0 -36.13403,-7.44423 -42.15625,-14.875 z"
+         id="path3785-2" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient3721-7"
+       id="linearGradient3727"
+       x1="-111"
+       y1="262"
+       x2="-111"
+       y2="183.99359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(260)" />
+    <linearGradient
+       id="linearGradient3721-7">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0"
+         id="stop3723-9" />
+      <stop
+         id="stop3925-9"
+         offset="0.5"
+         style="stop-color:#f4f4f3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fbfbfa;stop-opacity:1"
+         offset="1"
+         id="stop3725-1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3927-4"
+       id="linearGradient3923"
+       gradientUnits="userSpaceOnUse"
+       x1="-111"
+       y1="268.14868"
+       x2="-111"
+       y2="195.98666"
+       gradientTransform="translate(260)" />
+    <linearGradient
+       id="linearGradient3927-4">
+      <stop
+         id="stop3929-9"
+         offset="0"
+         style="stop-color:#c8cdc3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0.10637173"
+         id="stop3931-0" />
+      <stop
+         id="stop3933-9"
+         offset="1"
+         style="stop-color:#fbfbfa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3873-8"
+       id="linearGradient3879-8"
+       x1="-445.5"
+       y1="237.42877"
+       x2="-445.5"
+       y2="256.75098"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3873-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3875-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3877-1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3865-5">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -422,184 c -30.11111,0 -36.13403,7.44423 -42.15625,14.875 l -55.625,68.625 c 0.57753,0.30447 1.23679,0.5 1.9375,0.5 h 191.6875 c 0.70071,0 1.35997,-0.19553 1.9375,-0.5 l -55.625,-68.625 C -385.86599,191.44423 -391.88885,184 -422,184 Z"
+         id="path3867-3" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient3895-0"
+       id="linearGradient3901-6"
+       x1="-393"
+       y1="153"
+       x2="-336"
+       y2="242"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3895-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3897-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3899-2" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3887-0">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -382,38 c -30.11111,0 -36.13403,7.44423 -42.15625,14.875 L -482,130 v 133.84375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 c 2.29622,0 4.15625,-1.86002 4.15625,-4.15625 V 130 L -339.84375,52.875 C -345.86598,45.444228 -351.88885,38 -382,38 Z"
+         id="path3889-7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3911-1">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         d="m -412,38 c -30.11111,0 -36.13403,7.44423 -42.15625,14.875 L -512,130 v 133.84375 c 0,2.29622 1.86004,4.15625 4.15625,4.15625 h 191.6875 c 2.29622,0 4.15625,-1.86002 4.15625,-4.15625 V 130 L -369.84375,52.875 C -375.86598,45.444228 -381.88885,38 -412,38 Z"
+         id="path3913-5" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient2152"
+       id="linearGradient10356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.537475,0,0,0.477257,4.995766,7.023296)"
+       x1="8.9156475"
+       y1="37.197018"
+       x2="9.8855038"
+       y2="52.090679" />
+    <radialGradient
+       xlink:href="#linearGradient10691"
+       id="radialGradient10358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.902215,0.525703)"
+       cx="6.702713"
+       cy="73.615715"
+       fx="6.702713"
+       fy="73.615715"
+       r="7.228416" />
+    <radialGradient
+       xlink:href="#linearGradient37935"
+       id="radialGradient10360"
+       gradientUnits="userSpaceOnUse"
+       cx="8.7468252"
+       cy="6.8283234"
+       fx="8.7468252"
+       fy="6.8283234"
+       r="29.889715" />
+    <radialGradient
+       xlink:href="#linearGradient2145"
+       id="radialGradient10362"
+       gradientUnits="userSpaceOnUse"
+       cx="11.901996"
+       cy="10.045444"
+       fx="11.901996"
+       fy="10.045444"
+       r="29.292715" />
+    <linearGradient
+       xlink:href="#linearGradient2111"
+       id="linearGradient10366"
+       gradientUnits="userSpaceOnUse"
+       x1="13.037439"
+       y1="8.3119221"
+       x2="19.359053"
+       y2="17.322744" />
+    <linearGradient
+       xlink:href="#linearGradient2111"
+       id="linearGradient10368"
+       gradientUnits="userSpaceOnUse"
+       x1="13.037439"
+       y1="-1.5875777"
+       x2="19.359053"
+       y2="7.423245" />
+    <linearGradient
+       xlink:href="#linearGradient2111"
+       id="linearGradient10370"
+       gradientUnits="userSpaceOnUse"
+       x1="17.987192"
+       y1="3.3621745"
+       x2="24.308804"
+       y2="12.372997" />
+    <linearGradient
+       xlink:href="#linearGradient2111"
+       id="linearGradient10372"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0876923"
+       y1="3.3621745"
+       x2="14.409305"
+       y2="12.372997" />
+    <radialGradient
+       xlink:href="#linearGradient10691"
+       id="radialGradient11162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.902215,0.525703)"
+       cx="6.702713"
+       cy="73.615715"
+       fx="6.702713"
+       fy="73.615715"
+       r="7.228416" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11191">
+      <path
+         id="path11193"
+         d="m 273.21875,117.09375 c -32.50839,0 -58.875,26.39786 -58.875,58.90625 0,32.50839 26.36661,58.875 58.875,58.875 32.50839,0 58.90625,-26.36661 58.90625,-58.875 0,-32.50839 -26.39786,-58.90625 -58.90625,-58.90625 z m -0.25,15.03125 c 24.06826,0 43.59375,19.55674 43.59375,43.625 0,24.06826 -19.52549,43.59375 -43.59375,43.59375 -24.06826,0 -43.59375,-19.52549 -43.59375,-43.59375 0,-24.06826 19.52549,-43.625 43.59375,-43.625 z"
+         style="fill:none;stroke:#000000;stroke-opacity:1" />
+    </clipPath>
+    <radialGradient
+       xlink:href="#linearGradient11225"
+       id="radialGradient11231"
+       cx="177"
+       cy="139.125"
+       fx="177"
+       fy="139.125"
+       r="49"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)" />
+    <radialGradient
+       xlink:href="#linearGradient11225"
+       id="radialGradient11235"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)"
+       cx="177"
+       cy="208.00182"
+       fx="177"
+       fy="208.00182"
+       r="49" />
+    <radialGradient
+       xlink:href="#linearGradient11225"
+       id="radialGradient11247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)"
+       cx="177"
+       cy="139.125"
+       fx="177"
+       fy="139.125"
+       r="49" />
+    <radialGradient
+       xlink:href="#linearGradient11225"
+       id="radialGradient11251"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)"
+       cx="179.1151"
+       cy="207.61333"
+       fx="179.1151"
+       fy="207.61333"
+       r="49" />
+    <radialGradient
+       xlink:href="#linearGradient11257"
+       id="radialGradient11255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)"
+       cx="177"
+       cy="209.87154"
+       fx="177"
+       fy="209.87154"
+       r="49" />
+    <radialGradient
+       xlink:href="#linearGradient11225"
+       id="radialGradient11269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2322723,0,0,1.2322723,-41.112189,-32.314878)"
+       cx="177"
+       cy="139.125"
+       fx="177"
+       fy="139.125"
+       r="49" />
+    <radialGradient
+       xlink:href="#linearGradient11349"
+       id="radialGradient11355"
+       cx="282.43289"
+       cy="169.76842"
+       fx="282.43289"
+       fy="169.76842"
+       r="12.83613"
+       gradientTransform="matrix(0.0464,-0.17224595,0.56978494,0.15348994,-96.263932,47.397674)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient11359"
+       id="radialGradient11365"
+       cx="167.75"
+       cy="190.625"
+       fx="167.75"
+       fy="190.625"
+       r="6.125"
+       gradientTransform="matrix(0.76856474,0.40134631,-0.66724571,1.2777532,166.01698,-120.27255)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient11359"
+       id="radialGradient11369"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80065965,-0.33273825,0.9041829,2.1757124,-105.57674,-161.3059)"
+       cx="151.72693"
+       cy="169.73349"
+       fx="151.72693"
+       fy="169.73349"
+       r="6.125" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11375">
+      <circle
+         transform="translate(0,2.1357249)"
+         id="path11377"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:#000000;stroke-width:2.13572;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         cx="176.625"
+         cy="176.375"
+         r="46.875" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient2274-7">
+      <stop
+         id="stop2276-6"
+         offset="0.0000000"
+         style="stop-color:#000000;stop-opacity:0.12871288;" />
+      <stop
+         id="stop2278-0"
+         offset="1.0000000"
+         style="stop-color:#000000;stop-opacity:0.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9749-5">
+      <stop
+         id="stop9751-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9753-4"
+         offset="1.0000000"
+         style="stop-color:#ededed;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2152-3">
+      <stop
+         id="stop2154-8"
+         offset="0.0000000"
+         style="stop-color:#9aa29a;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2156-0"
+         offset="1.0000000"
+         style="stop-color:#b5beb5;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2166-14">
+      <stop
+         id="stop2168-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2170-5"
+         offset="1.0000000"
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18913-5">
+      <stop
+         id="stop18915-9"
+         offset="0.0000000"
+         style="stop-color:#ededed;stop-opacity:1.0000000;" />
+      <stop
+         id="stop18917-0"
+         offset="1.0000000"
+         style="stop-color:#c8c8c8;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15107-6">
+      <stop
+         id="stop15109-5"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop15111-9"
+         offset="1.0000000"
+         style="stop-color:#e2e2e2;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2136-00">
+      <stop
+         id="stop2138-9"
+         offset="0.0000000"
+         style="stop-color:#989690;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2140-20"
+         offset="1.0000000"
+         style="stop-color:#656460;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient37935-5">
+      <stop
+         id="stop37937-8"
+         offset="0.0000000"
+         style="stop-color:#9497b3;stop-opacity:1.0000000;" />
+      <stop
+         id="stop37939-73"
+         offset="1.0000000"
+         style="stop-color:#4c4059;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2145-8">
+      <stop
+         style="stop-color:#fffffd;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2147-6" />
+      <stop
+         style="stop-color:#cbcbc9;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2149-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient42174-9">
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop42176-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop42178-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2111-1">
+      <stop
+         style="stop-color:#838383;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2113-9" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2115-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10653-77">
+      <stop
+         style="stop-color:#f3f4ff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop10655-2" />
+      <stop
+         style="stop-color:#9193af;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048-1">
+      <stop
+         id="stop5050-0"
+         offset="0"
+         style="stop-color:black;stop-opacity:0;" />
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0.5"
+         id="stop5056-7" />
+      <stop
+         id="stop5052-9"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="129.75"
+       x2="-372.5"
+       y1="164.82263"
+       x1="-372.5"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13988"
+       xlink:href="#linearGradient3851-0" />
+    <linearGradient
+       y2="49.516186"
+       x2="-324"
+       y1="-17.50746"
+       x1="-324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13990"
+       xlink:href="#linearGradient3791-3" />
+    <linearGradient
+       y2="256.75098"
+       x2="-445.5"
+       y1="237.42877"
+       x1="-445.5"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13996"
+       xlink:href="#linearGradient3873-8" />
+    <linearGradient
+       y2="242"
+       x2="-336"
+       y1="153"
+       x1="-393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13998"
+       xlink:href="#linearGradient3895-0" />
+    <linearGradient
+       y2="-74.509018"
+       x2="-393.5"
+       y1="53.754749"
+       x1="-393.5"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient14030"
+       xlink:href="#linearGradient3751-7" />
+    <filter
+       id="filter4421"
+       x="-0.018105986"
+       y="-0.014882733"
+       width="1.036212"
+       height="1.0297655">
+      <feGaussianBlur
+         stdDeviation="0.48370442"
+         id="feGaussianBlur4423" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4435">
+      <path
+         id="path4437"
+         d="m 45.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.648967 39.08042,-115.260419 87.28855,-115.260419 48.20813,0 87.28855,56.611452 87.28855,115.260419 z"
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;enable-background:new" />
+    </clipPath>
+    <radialGradient
+       xlink:href="#linearGradient4449"
+       id="radialGradient4455"
+       cx="272.38095"
+       cy="582.83838"
+       fx="272.38095"
+       fy="582.83838"
+       r="354.28571"
+       gradientTransform="matrix(1,0,0,0.32526883,0,393.25922)"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4447">
+      <path
+         id="path4449"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 235.10454,132.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 m 0,0 v 15 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4451">
+      <path
+         id="path4453"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 235.10454,132.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 m 0,0 v 15 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4455">
+      <path
+         id="path4457"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 235.10454,132.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 m 0,0 v 15 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4459">
+      <path
+         id="path4461"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4463">
+      <path
+         id="path4465"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4467">
+      <path
+         id="path4469"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4471">
+      <path
+         id="path4473"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4475">
+      <path
+         id="path4477"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4479">
+      <path
+         id="path4481"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 235.10454,137.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286 v 10 m 0,0 c 0,21.01049 38.871426,38.04286 86.821766,38.04286 47.95033,0 86.82176,-17.03237 86.82176,-38.04286 v -10" />
+    </clipPath>
+    <filter
+       id="filter4562"
+       x="-0.011633709"
+       y="-0.033386508"
+       width="1.0232674"
+       height="1.0864876">
+      <feGaussianBlur
+         stdDeviation="0.52921596"
+         id="feGaussianBlur4564" />
+    </filter>
+    <filter
+       id="filter4570"
+       x="-0.011633709"
+       y="-0.033386508"
+       width="1.0232674"
+       height="1.0864876">
+      <feGaussianBlur
+         stdDeviation="0.52921596"
+         id="feGaussianBlur4572" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4630">
+      <path
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;enable-background:new"
+         d="m 405.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.648967 39.08042,-115.260419 87.28855,-115.260419 48.20813,0 87.28855,56.611452 87.28855,115.260419 z"
+         id="path4632" />
+    </clipPath>
+    <filter
+       id="filter4662"
+       x="-0.061421132"
+       y="-0.054226466"
+       width="1.1228423"
+       height="1.1084529">
+      <feGaussianBlur
+         stdDeviation="10.416"
+         id="feGaussianBlur4664" />
+    </filter>
+    <radialGradient
+       xlink:href="#linearGradient4522"
+       id="radialGradient4814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.23779029,1.8722612,-1.2481718,-0.15852657,257.38588,-164.5538)"
+       cx="124.14905"
+       cy="79.181145"
+       fx="124.14905"
+       fy="79.181145"
+       r="87.288551" />
+    <radialGradient
+       xlink:href="#linearGradient4387"
+       id="radialGradient5083"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526883,0,393.25922)"
+       cx="272.38095"
+       cy="582.83838"
+       fx="272.38095"
+       fy="582.83838"
+       r="354.28571" />
+    <radialGradient
+       xlink:href="#linearGradient4401"
+       id="radialGradient5085"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526883,0,393.25922)"
+       cx="272.38095"
+       cy="582.83838"
+       fx="272.38095"
+       fy="582.83838"
+       r="354.28571" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5170">
+      <path
+         id="path5172"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 234.14408,137.69439 c 0,21.01049 -39.15556,38.04286 -87.45638,38.04286 -48.300829,0 -87.456391,-17.03237 -87.456391,-38.04286 m 0,0 v 15 c 0,21.01049 39.155562,38.04286 87.456391,38.04286 48.30082,0 87.45638,-17.03237 87.45638,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5174">
+      <path
+         id="path5176"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 234.14408,137.69439 c 0,21.01049 -39.15556,38.04286 -87.45638,38.04286 -48.300829,0 -87.456391,-17.03237 -87.456391,-38.04286 m 0,0 v 15 c 0,21.01049 39.155562,38.04286 87.456391,38.04286 48.30082,0 87.45638,-17.03237 87.45638,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5178">
+      <path
+         id="path5180"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 234.14408,137.69439 c 0,21.01049 -39.15556,38.04286 -87.45638,38.04286 -48.300829,0 -87.456391,-17.03237 -87.456391,-38.04286 m 0,0 v 15 c 0,21.01049 39.155562,38.04286 87.456391,38.04286 48.30082,0 87.45638,-17.03237 87.45638,-38.04286 v -15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5182">
+      <path
+         id="path5184"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 234.14505,142.69439 c 0,21.01049 -39.156,38.04286 -87.45735,38.04286 -48.301376,0 -87.457362,-17.03237 -87.457362,-38.04286 v 10 m 0,0 c 0,21.01049 39.155986,38.04286 87.457362,38.04286 48.30135,0 87.45735,-17.03237 87.45735,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5186">
+      <path
+         id="path5188"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 234.14505,142.69439 c 0,21.01049 -39.156,38.04286 -87.45735,38.04286 -48.301376,0 -87.457362,-17.03237 -87.457362,-38.04286 v 10 m 0,0 c 0,21.01049 39.155986,38.04286 87.457362,38.04286 48.30135,0 87.45735,-17.03237 87.45735,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5190">
+      <path
+         id="path5192"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 234.14505,142.69439 c 0,21.01049 -39.156,38.04286 -87.45735,38.04286 -48.301376,0 -87.457362,-17.03237 -87.457362,-38.04286 v 10 m 0,0 c 0,21.01049 39.155986,38.04286 87.457362,38.04286 48.30135,0 87.45735,-17.03237 87.45735,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5194">
+      <path
+         id="path5196"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 234.14505,142.69439 c 0,21.01049 -39.156,38.04286 -87.45735,38.04286 -48.301376,0 -87.457362,-17.03237 -87.457362,-38.04286 v 10 m 0,0 c 0,21.01049 39.155986,38.04286 87.457362,38.04286 48.30135,0 87.45735,-17.03237 87.45735,-38.04286 v -10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5198">
+      <path
+         id="path5200"
+         style="display:inline;fill:#73d216;stroke:none;enable-background:new"
+         d="m 234.14505,142.69439 c 0,21.01049 -39.156,38.04286 -87.45735,38.04286 -48.301376,0 -87.457362,-17.03237 -87.457362,-38.04286 v 10 m 0,0 c 0,21.01049 39.155986,38.04286 87.457362,38.04286 48.30135,0 87.45735,-17.03237 87.45735,-38.04286 v -10" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient11149">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop11151" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop11153" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter11205"
+       x="-0.095939086"
+       width="1.1918782"
+       y="-0.19187817"
+       height="1.3837563">
+      <feGaussianBlur
+         stdDeviation="1.7588832"
+         id="feGaussianBlur11207" />
+    </filter>
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient11159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter11193"
+       x="-0.24657445"
+       width="1.4931489"
+       y="-0.49314891"
+       height="1.9862978">
+      <feGaussianBlur
+         stdDeviation="4.5205316"
+         id="feGaussianBlur11195" />
+    </filter>
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4224"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4226"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="209.04451"
+       cy="235.93333"
+       fx="228.88376"
+       fy="235.93333"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient4522"
+       id="radialGradient4275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.23779029,1.8722612,-1.2481718,-0.15852657,257.38588,-164.5538)"
+       cx="124.14905"
+       cy="79.181145"
+       fx="124.14905"
+       fy="79.181145"
+       r="87.288551" />
+    <radialGradient
+       xlink:href="#linearGradient4818"
+       id="radialGradient4277"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.73829141,-1.9279401,1.4409183,-0.55178977,120.92466,745.30879)"
+       cx="218.58803"
+       cy="176.7899"
+       fx="218.58803"
+       fy="176.7899"
+       r="87.288551" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4279">
+      <path
+         style="display:inline;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:none;enable-background:new"
+         d="m 235.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.648967 39.08042,-115.260419 87.28855,-115.260419 48.20813,0 87.28855,56.611452 87.28855,115.260419 z"
+         id="path4281" />
+    </clipPath>
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4291"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient11149"
+       id="radialGradient4295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="209.04451"
+       cy="235.93333"
+       fx="228.88376"
+       fy="235.93333"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient4818-9"
+       id="radialGradient4826"
+       cx="218.58803"
+       cy="176.7899"
+       fx="218.58803"
+       fy="176.7899"
+       r="87.288551"
+       gradientTransform="matrix(-0.73829141,-1.9279401,1.4409183,-0.55178977,180.92466,745.30879)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4818-9">
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1;"
+         offset="0"
+         id="stop4820-7" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:0;"
+         offset="1"
+         id="stop4822-3" />
+    </linearGradient>
+    <radialGradient
+       r="87.288551"
+       fy="176.7899"
+       fx="218.58803"
+       cy="176.7899"
+       cx="218.58803"
+       gradientTransform="matrix(-0.73829141,-1.9279401,1.4409183,-0.55178977,120.92466,745.30879)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3417"
+       xlink:href="#linearGradient4818-9" />
+    <radialGradient
+       xlink:href="#linearGradient11149-4"
+       id="radialGradient4224-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <linearGradient
+       id="linearGradient11149-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop11151-5" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop11153-3" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient11149-4"
+       id="radialGradient4226-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       r="22"
+       fy="233"
+       fx="210"
+       cy="233"
+       cx="210"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4220"
+       xlink:href="#linearGradient11149-4" />
+    <linearGradient
+       xlink:href="#linearGradient4203"
+       id="linearGradient4211"
+       x1="-87.005768"
+       y1="27.083328"
+       x2="-37.678669"
+       y2="221.33333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient4203"
+       id="linearGradient4268"
+       gradientUnits="userSpaceOnUse"
+       x1="-87.005768"
+       y1="27.083328"
+       x2="-37.678669"
+       y2="221.33333" />
+    <filter
+       id="filter4270"
+       x="-0.022902609"
+       y="-0.018759336"
+       width="1.0458052"
+       height="1.0375187">
+      <feGaussianBlur
+         stdDeviation="1.4267578"
+         id="feGaussianBlur4272" />
+    </filter>
+    <radialGradient
+       xlink:href="#linearGradient11149-4"
+       id="radialGradient4324"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <radialGradient
+       xlink:href="#linearGradient11149-4"
+       id="radialGradient4326"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.5,0,116.5)"
+       cx="210"
+       cy="233"
+       fx="210"
+       fy="233"
+       r="22" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4304">
+      <path
+         id="path4306"
+         d="m 59.09225,127.21241 v 25.26778 c 0,21.01054 39.061717,37.71387 87.3625,37.71387 48.30079,0 87.83989,-16.70333 87.83989,-37.71387 v -25.26778 c 0,21.01054 -39.5391,38.19126 -87.83989,38.19126 -48.300783,0 -87.3625,-17.18072 -87.3625,-38.19126 z"
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4352">
+      <path
+         style="display:inline;fill:#4e9a06;stroke:none;enable-background:new"
+         d="m 61.655591,124.15318 v 7.15457 5.9087 7.15457 c 0,21.0105 39.257399,37.817 87.558279,37.817 48.30077,0 87.21758,-16.8065 87.21758,-37.817 v -7.15457 -7.83595 -5.22732 c 0,21.0105 -38.91681,37.817 -87.21758,37.817 -48.30088,0 -87.558279,-16.8065 -87.558279,-37.817 z"
+         id="path4354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4595">
+      <path
+         id="path4597"
+         d="m -14.282595,8.1440635 v 1.4185643 c 0,0.9634652 2.014718,1.7441142 4.4999998,1.7441142 2.4852812,0 4.5000002,-0.780649 4.5000002,-1.7441142 V 8.1440635 c 0,0.5866082 -0.753237,1.1023152 -1.898438,1.4185643 -0.7357131,0.2031681 -1.6294525,0.3255484 -2.6015622,0.3255484 -0.9721098,0 -1.8678018,-0.1223803 -2.6035158,-0.3255484 -1.1452,-0.3162491 -1.896484,-0.8319561 -1.896484,-1.4185643 z"
+         style="fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4595-4">
+      <path
+         id="path4597-2"
+         d="m -14.282595,8.1440635 v 1.4185643 c 0,0.9634652 2.014718,1.7441142 4.4999998,1.7441142 2.4852812,0 4.5000002,-0.780649 4.5000002,-1.7441142 V 8.1440635 c 0,0.5866082 -0.753237,1.1023152 -1.898438,1.4185643 -0.7357131,0.2031681 -1.6294525,0.3255484 -2.6015622,0.3255484 -0.9721098,0 -1.8678018,-0.1223803 -2.6035158,-0.3255484 -1.1452,-0.3162491 -1.896484,-0.8319561 -1.896484,-1.4185643 z"
+         style="fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="LGPL" />
+        <dc:title>Evolution</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>evolution</rdf:li>
+            <rdf:li>mail</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     id="layer3"
+     transform="translate(-24.335725,-28.810156)">
+    <rect
+       y="20"
+       x="20"
+       height="256"
+       width="256"
+       id="rect6282"
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       id="rect6284"
+       width="48"
+       height="48"
+       x="296.0625"
+       y="39.99633" />
+    <rect
+       y="115.99633"
+       x="303"
+       height="32"
+       width="32"
+       id="rect6592"
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       id="rect6749"
+       width="22"
+       height="22"
+       x="303"
+       y="167.05884" />
+    <rect
+       y="209"
+       x="303"
+       height="16"
+       width="16"
+       id="rect6833"
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+    <rect
+       y="166"
+       x="302"
+       height="24"
+       width="24"
+       id="rect5028"
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+       x="21"
+       y="-18.999996"
+       id="context"><tspan
+         id="tspan16843"
+         x="21"
+         y="-18.999996"
+         style="font-size:20px;line-height:1.25">apps</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+       x="159"
+       y="-18.999996"
+       id="icon-name"><tspan
+         id="tspan16847"
+         x="159"
+         y="-18.999996"
+         style="font-size:20px;line-height:1.25">gnome-pomodoro</tspan></text>
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       id="rect3932"
+       width="16"
+       height="16"
+       x="303"
+       y="249" />
+  </g>
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-24.335725,-28.810156)">
+    <g
+       id="g4215">
+      <g
+         transform="matrix(1,0,0,1.0645684,0,-18.108994)"
+         id="g4219">
+        <ellipse
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.666667;fill:url(#radialGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.1;marker:none;filter:url(#filter11193);enable-background:accumulate"
+           id="path11157"
+           transform="matrix(3.6884922,0,0,1.8365503,-629.08334,-192.85557)"
+           cx="210"
+           cy="233"
+           rx="22"
+           ry="11" />
+        <ellipse
+           transform="matrix(1.9571594,0,0,1.5916772,-265.50346,-137.14688)"
+           id="path10371"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.1;marker:none;filter:url(#filter11205);enable-background:accumulate"
+           cx="210"
+           cy="233"
+           rx="22"
+           ry="11" />
+      </g>
+      <g
+         id="g4716">
+        <path
+           style="display:inline;fill:url(#radialGradient4814);fill-opacity:1;fill-rule:nonzero;stroke:none;enable-background:new"
+           d="m 235.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.64897 39.08042,-115.260419 87.28855,-115.260419 48.20813,0 87.28855,56.611449 87.28855,115.260419 z"
+           id="path3215" />
+        <g
+           clip-path="url(#clipPath4279)"
+           id="g4741">
+          <g
+             style="fill:#555753"
+             transform="translate(0,-3)"
+             id="g4532">
+            <path
+               id="rect4033"
+               d="m 131.19084,204.04836 12.8181,-12.81806 12.81815,12.81806 z"
+               style="fill:#434441;fill-opacity:1;stroke:none" />
+            <path
+               id="path4240"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.52253px;line-height:125%;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#434441;fill-opacity:1;stroke:none"
+               d="m 140.09243,165.18575 h -14.60229 v -3.54842 l 5.12047,-6.12259 c 0.64503,-0.77024 1.2305,-1.4805 1.75646,-2.12933 0.52594,-0.64884 0.97744,-1.28195 1.35454,-1.89832 0.3771,-0.6159 0.66982,-1.24311 0.87822,-1.88112 0.20836,-0.63803 0.31261,-1.32618 0.31261,-2.06299 -2e-5,-0.81399 -0.22326,-1.44659 -0.66982,-1.89783 -0.43667,-0.45222 -1.0271,-0.67684 -1.77135,-0.67684 -0.78396,0 -1.53812,0.21627 -2.26252,0.64342 -0.72442,0.42764 -1.48355,1.03961 -2.27743,1.83196 l -2.50068,-3.28397 c 0.44656,-0.45222 0.91294,-0.88034 1.39919,-1.28732 0.48623,-0.41781 1.02211,-0.78697 1.60759,-1.10596 0.58547,-0.31951 1.23049,-0.57265 1.93505,-0.75945 0.70457,-0.19659 1.49348,-0.29491 2.36674,-0.29491 1.04194,0 1.97474,0.1573 2.79841,0.47679 0.83355,0.3195 1.54307,0.77614 2.12857,1.37042 0.58546,0.58295 1.032,1.29274 1.33965,2.12885 0.31757,0.83609 0.47632,1.7769 0.47633,2.82191 -1e-5,0.9467 -0.14888,1.85408 -0.44658,2.72361 -0.29774,0.85822 -0.70457,1.70513 -1.22058,2.54124 -0.51603,0.8253 -1.1164,1.65108 -1.80109,2.47589 -0.67481,0.81399 -1.39921,1.64516 -2.17323,2.4921 l -2.61978,2.9212 v 0.23103 h 8.87152 v 4.29112" />
+            <path
+               id="path4242"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.52253px;line-height:125%;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#434441;fill-opacity:1;stroke:none"
+               d="m 152.74182,149.77063 c 0.99468,0 1.9206,0.1573 2.77775,0.48171 0.85713,0.31949 1.60315,0.78597 2.23809,1.40284 0.63489,0.61591 1.13225,1.38615 1.49206,2.31023 0.35974,0.91328 0.53965,1.96419 0.53966,3.15273 -1e-5,1.30895 -0.19577,2.4862 -0.5873,3.5317 -0.39155,1.0342 -0.96825,1.91454 -1.73014,2.64054 -0.76191,0.71519 -1.70899,1.26522 -2.84124,1.65058 -1.12171,0.38832 -2.41271,0.57756 -3.873,0.57756 -0.58202,0 -1.15873,-0.049 -1.73015,-0.0787 -0.57142,-0.0541 -1.12169,-0.13763 -1.65077,-0.24577 -0.51853,-0.0983 -1.01588,-0.23103 -1.49206,-0.39814 -0.46563,-0.16714 -0.88889,-0.35883 -1.26983,-0.57757 v -4.40663 c 0.37036,0.22118 0.79893,0.43255 1.2857,0.6272 0.48677,0.18676 0.98941,0.34899 1.50793,0.49497 0.52909,0.13272 1.05818,0.24087 1.5873,0.32933 0.52908,0.0787 1.03171,0.11803 1.50791,0.11803 1.41798,0 2.49733,-0.29982 3.23807,-0.90738 0.74074,-0.6159 1.1111,-1.58963 1.11111,-2.92121 -1e-5,-1.18853 -0.36508,-2.09052 -1.09523,-2.70689 -0.71958,-0.62721 -1.83597,-0.9408 -3.34917,-0.9408 -0.27519,0 -0.57145,0 -0.8889,0.0491 -0.30683,0.0493 -0.61375,0.0738 -0.92063,0.12779 -0.29637,0.0541 -0.58201,0.11804 -0.85714,0.18187 -0.27513,0.0541 -0.51323,0.11791 -0.71427,0.18188 l -1.95237,-1.08925 0.873,-12.29581 h 12.2539 v 4.32455 h -7.99996 l -0.38094,4.73692 c 0.33865,-0.0787 0.73015,-0.15237 1.1746,-0.23592 0.45499,-0.0738 1.03703,-0.11792 1.74602,-0.11792" />
+            <path
+               style="fill:#555753;stroke:#434441;stroke-width:7.19695;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 142.78333,165.52939 v 26.52695"
+               id="path6446"
+               clip-path="url(#clipPath4455)" />
+            <path
+               id="path6448"
+               d="M 99.437422,156.89628 V 184.8835"
+               style="fill:#555753;stroke:#434441;stroke-width:6.23735;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               clip-path="url(#clipPath4451)" />
+            <path
+               style="fill:#555753;stroke:#434441;stroke-width:4.79796;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 66.60782,138.3148 v 29.03937"
+               id="path6450"
+               clip-path="url(#clipPath4447)" />
+            <path
+               id="path6456"
+               d="M 131.07926,163.90755 V 193.1057"
+               style="fill:#555753;stroke:#434441;stroke-width:4.79796;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               clip-path="url(#clipPath4479)" />
+            <path
+               style="fill:#555753;stroke:#434441;stroke-width:4.55807;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 120.09819,162.21096 v 29.41339"
+               id="path6458"
+               clip-path="url(#clipPath4475)" />
+            <path
+               id="path6460"
+               d="m 109.5509,160.90723 v 26.72262"
+               style="fill:#555753;stroke:#434441;stroke-width:4.31817;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               clip-path="url(#clipPath4471)" />
+            <path
+               style="fill:#555753;stroke:#434441;stroke-width:4.07827;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 90.362421,152.90457 v 28.71401"
+               id="path6466"
+               clip-path="url(#clipPath4467)" />
+            <path
+               id="path6468"
+               d="m 82.010428,149.48127 v 27.94194"
+               style="fill:#555753;stroke:#434441;stroke-width:3.83837;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               clip-path="url(#clipPath4463)" />
+            <path
+               style="fill:#555753;stroke:#434441;stroke-width:3.59847;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="M 73.803025,145.39788 V 171.8857"
+               id="path6470"
+               clip-path="url(#clipPath4459)" />
+          </g>
+          <path
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4562);enable-background:new"
+             d="m 235.10454,146.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286"
+             id="path4392" />
+          <path
+             id="path3217"
+             d="m 235.10454,144.60248 c 0,21.01049 -38.87143,38.04286 -86.82176,38.04286 -47.95034,0 -86.821766,-17.03237 -86.821766,-38.04286"
+             style="display:inline;opacity:0.292683;fill:none;stroke:#2e3436;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4570);enable-background:new" />
+        </g>
+        <path
+           style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter4662)"
+           d="M 118,-121 V 340 H 525 V -121 Z M 312.28125,31.125 c 48.20813,0 86.28125,41.632283 86.28125,100.28125 0,58.64894 -36.07312,106.125 -84.28125,106.125 C 266.07312,237.53125 239,194.0552 239,135.40625 239,76.757283 264.07312,31.125 312.28125,31.125 Z"
+           id="rect4580"
+           clip-path="url(#clipPath4630)"
+           transform="translate(-170)" />
+        <path
+           id="path4816"
+           d="m 235.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.64897 39.08042,-115.26042 87.28855,-115.26042 48.20813,0 87.28855,56.61145 87.28855,115.26042 z"
+           style="display:inline;opacity:0.1;fill:url(#radialGradient3417);fill-opacity:1;fill-rule:nonzero;stroke:none;enable-background:new" />
+        <path
+           id="path4419"
+           d="m 45.57133,146.40054 c 0,58.64894 -39.08042,97.12601 -87.28855,97.12601 -48.20813,0 -87.28855,-38.47707 -87.28855,-97.12602 0,-58.648967 39.08042,-115.260419 87.28855,-115.260419 48.20813,0 87.28855,56.611452 87.28855,115.260419 z"
+           style="display:inline;fill:none;stroke:url(#linearGradient4268);stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4421);enable-background:new"
+           clip-path="url(#clipPath4435)"
+           transform="translate(190)" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4270);enable-background:new"
+           id="path4427"
+           d="m 148.28125,32.734375 c -23.47351,0 -44.84683,13.801306 -60.421875,34.992187 -15.575042,21.190882 -25.25,49.712808 -25.25,78.679688 0,57.93375 38.320545,95.51563 85.671875,95.51563 47.35133,0 85.67187,-37.58189 85.67187,-95.51563 0,-28.96688 -9.67495,-57.488806 -25.25,-78.679688 C 193.12808,46.535681 171.75476,32.734375 148.28125,32.734375 Z" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary (not necessary)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently on Gnome 42.4 Gnome Pomodoro is missing its icon.

Issue Number: N/A

## What is the new behavior?

After installing the scalable SVG icon, the icon is shown in the search, app grid and dash.

