### PR TITLE
Make Timer always default page

### DIFF
--- a/src/window.vala
+++ b/src/window.vala
@@ -103,15 +103,7 @@ namespace Pomodoro
             // TODO: this.default_page should be set from application.vala
             var application = Pomodoro.Application.get_default ();
 
-            // if (application.capabilities.has_enabled ("task-list")) {  // TODO
-            //     this.default_page = "task-list";
-            // }
-            if (application.capabilities.has_capability ("indicator")) {
-                this.default_page = "stats";
-            }
-            else {
-                this.default_page = "timer";
-            }
+            this.default_page = "timer";
 
             this.stack.visible_child_name = this.default_page;
 


### PR DESCRIPTION
## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [x] ~Extended the README / documentation, if necessary~

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: Fixes #494 

Stats tab is the default. Seems to only be default when there is an indicator available. Not very clear why this choice was made, since it introduces inconsistency across DEs, and adds a needless extra click for the most common use case, which is starting a session:

1. open app
2. (find and) the click indicator icon
3. (find and) click the Start button

or

1. open app
2. switch to Timer tab
3. click the start button

Also, this check for the availability of the indicator icon seems to have been a temporary solution, left as a TODO 6 years ago. Eventually the solution seems to be adding a setting for it. For now, a better default is what follows:

## What is the new behavior?

Timer tab is always default.

So now to start a new session:
1. open app
4. click the big Start ▶ button

## Other information
To me (and 6 other people on the issue) this seems like a clear improvement in UX.
