### PR TITLE
Flatpak build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/org.gnome.Pomodoro.json
+++ b/org.gnome.Pomodoro.json
@@ -48,7 +48,8 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dlua51=false",
-                "-Dpython3=false"
+                "-Dpython3=false",
+                "-Ddemos=false"
             ],
             "cleanup": [
                 "/bin/*",

--- a/org.gnome.Pomodoro.json
+++ b/org.gnome.Pomodoro.json
@@ -48,8 +48,7 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dlua51=false",
-                "-Dpython3=false",
-                "-Ddemos=false"
+                "-Dpython3=false"
             ],
             "cleanup": [
                 "/bin/*",
@@ -64,7 +63,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "branch": "master",
+                    "branch": "1.36",
                     "url": "https://gitlab.gnome.org/GNOME/libpeas.git"
                 }
             ]
@@ -83,9 +82,23 @@
                 }
             ]
         },
+                {
+            "name": "libcanberra",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--prefix=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "branch": "master",
+                    "url": "git://git.0pointer.net/libcanberra.git"
+                }
+            ]
+        },
         {
             "name": "gnome-pomodoro",
-            "buildsystem": "autotools",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "file",


### PR DESCRIPTION
## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

Currently, cloning the repo into something like GNOME Builder and attempting to build the project as a Flatpak fails. I'm not sure if it was working at one point, but it is now :smile: There are a few reasons for this:

- The dependency for `libpeas` references the  `master` branch, which no longer exists  (they renamed it to `main`).
- There is a dependency for `libcanberra` that doesn't seem to get resolved without adding it explicitly to the manifest so that it gets cloned and built.
- The build system for `gnome-pomodoro` is listed as `autotools` instead of `meson`.

## What is the new behavior?

-  The `libpeas` dependency is pinned to `1.3.6`. The most recent release (`1.99.0`) as well as the `master` branch [update the name of the pkgconfig file](https://gnome.pages.gitlab.gnome.org/libpeas/libpeas-2/) to `libpeas-2`. Even if you update `meson.build` as so:
    ```meson
    # peas_dep = dependency('libpeas-1.0', version: '>=1.5.0')
    peas_dep = dependency('libpeas-2', version: '>=1.99.0')
    ```

    It still can't find `libpeas-2`. I'm not sure why this is the case, and if someone would like to fix this that would be awesome as it will need to be addressed to update a version of `libpeas` beyond 1.3.6. Note that when it comes time to do that, the compile option `"-Ddemos=false"` no longer exists in [future versions](https://gitlab.gnome.org/GNOME/libpeas/-/blob/4084b1d5c9d30ef3409df31c74d40aa8aeaf7739/meson.build).
- The dependency for `libcanberra` is declared and handled in the manifest.
- The build system for `gnome-pomodoro` in the manifest is now `meson` instead of `autotools`.
- A `.gitignore` file has been created to prevent the `.flatpak-builder` directory created during the build process from being included in Git history. 

## Other information

Now that Flatpak builds are working, it would be awesome if the app could be distributed via flatpak and  available on [Flathub](https://flathub.org)!

I started using this app today and it's awesome. Thanks for all your hard work! :heart: 