### PR TITLE
appdata: translate=no properties

### DIFF
--- a/data/org.gnome.Pomodoro.appdata.xml.in
+++ b/data/org.gnome.Pomodoro.appdata.xml.in
@@ -33,7 +33,7 @@
   </screenshots>
   <url type="homepage">https://gnomepomodoro.org</url>
   <url type="bugtracker">https://github.com/gnome-pomodoro/gnome-pomodoro</url>
-  <developer_name translatable="no">Kamil Prusko</developer_name>
+  <developer_name translate="no">Kamil Prusko</developer_name>
   <update_contact>kamilprusko@gmail.com</update_contact>
   <kudos>
     <kudo>AppMenu</kudo>
@@ -45,7 +45,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="0.25.1" date="2024-03-28">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.25.1</p>
         <ul>
           <li>Fixes for GNOME Shell 46</li>
@@ -54,7 +54,7 @@
       </description>
     </release>
     <release version="0.25.0" date="2024-03-05">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.25.0</p>
         <ul>
           <li>Support for GNOME Shell 46</li>
@@ -63,7 +63,7 @@
       </description>
     </release>
     <release version="0.24.1" date="2023-12-04">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.24.1</p>
         <ul>
           <li>Fixed timerState tracking and waking up of screen on the screen shield (thanks @real-or-random)</li>
@@ -71,7 +71,7 @@
       </description>
     </release>
     <release version="0.24.0" date="2023-08-27">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.24.0</p>
         <ul>
           <li>Marked extension as compatible with GNOME Shell 45 with no backwards compatibility</li>
@@ -81,7 +81,7 @@
       </description>
     </release>
     <release version="0.23.1" date="2023-03-31">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.23.1</p>
         <ul>
           <li>Fixed invalid appdata file</li>
@@ -89,7 +89,7 @@
       </description>
     </release>
     <release version="0.23.0" date="2023-03-26">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.23.0</p>
         <ul>
           <li>Marked extension as compatible with GNOME Shell 44 (thanks @jbicha)</li>
@@ -100,7 +100,7 @@
       </description>
     </release>
     <release version="0.22.1" date="2023-02-05">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.22.1</p>
         <ul>
           <li>Close screen overlay by hitting Esc key - a failsafe method</li>
@@ -112,7 +112,7 @@
       </description>
     </release>
     <release version="0.22.0" date="2022-10-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.22.0</p>
         <ul>
           <li>Marked extension as compatible with GNOME Shell 43 (thanks @jbicha)</li>
@@ -127,7 +127,7 @@
       </description>
     </release>
     <release version="0.21.1" date="2022-05-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.21.1</p>
         <ul>
           <li>Fixed break overlay geting stuck at 0:01 on GNOME 42 (thanks @upsuper)</li>
@@ -135,7 +135,7 @@
       </description>
     </release>
     <release version="0.21.0" date="2022-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.21.0</p>
         <ul>
           <li>Support for GNOME Shell 42 (@milotype and @kappa)</li>
@@ -145,7 +145,7 @@
       </description>
     </release>
     <release version="0.20.0" date="2021-09-25">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.20.0</p>
         <ul>
           <li>Support for GNOME Shell 41 (@mbooth101)</li>
@@ -153,7 +153,7 @@
       </description>
     </release>
     <release version="0.19.2" date="2021-09-19">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.19.2</p>
         <ul>
           <li>Fixed GNOME Shell freezing the lockscreen</li>
@@ -164,7 +164,7 @@
       </description>
     </release>
     <release version="0.19.1" date="2021-04-09">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.19.1</p>
         <ul>
           <li>Support GNOME Shell 40.0, not 4.0</li>
@@ -172,7 +172,7 @@
       </description>
     </release>
     <release version="0.19.0" date="2021-04-04">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.19.0</p>
         <ul>
           <li>Support for GNOME Shell 4.0</li>
@@ -184,7 +184,7 @@
       </description>
     </release>
     <release version="0.18.0" date="2020-10-04">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.18.0</p>
         <ul>
           <li>Support for GNOME Shell 3.38 (@ignapk and @szpak)</li>
@@ -199,7 +199,7 @@
       </description>
     </release>
     <release version="0.17.0" date="2020-03-22">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.17.0</p>
         <ul>
           <li>Support for GNOME Shell 3.36</li>
@@ -208,7 +208,7 @@
       </description>
     </release>
     <release version="0.16.0" date="2019-10-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.16.0</p>
         <ul>
           <li>Support for GNOME Shell 3.34 only</li>
@@ -218,7 +218,7 @@
       </description>
     </release>
     <release version="0.15.1" date="2019-04-07">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.15.1</p>
         <ul>
           <li>Minor code cleanups</li>
@@ -226,7 +226,7 @@
       </description>
     </release>
     <release version="0.15.0" date="2019-04-07">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.15.0</p>
         <ul>
           <li>Minor code cleanups to support ES6 syntax</li>
@@ -238,7 +238,7 @@
       </description>
     </release>
     <release version="0.14.0" date="2018-11-24">
-      <description translatable="no">
+      <description translate="no">
         <p>Overview of changes in gnome-pomodoro 0.14.0</p>
         <ul>
           <li>Support for GNOME Shell 3.28 and 3.30 (@aerostitch)</li>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -27,7 +27,6 @@ plugins/gnome/extension/extension.js
 plugins/gnome/extension/indicator.js
 plugins/gnome/extension/notifications.js
 plugins/gnome/extension/presence.js
-plugins/gnome/extension/settings.js
 plugins/gnome/extension/timer.js
 plugins/gnome/extension/utils.js
 plugins/gnome/gnome-idle-monitor.vala


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract the
`translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process
before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### potfiles: Remove missing file

Remove missing settings.js to fix string extraction

## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [x] Translation related changes

