### PR TITLE
extension: Mark compatible with GNOME Shell 48

### DIFF
--- a/plugins/gnome/extension/metadata.json.in
+++ b/plugins/gnome/extension/metadata.json.in
@@ -2,7 +2,7 @@
   "uuid": "@EXTENSION_UUID@",
   "name": "Pomodoro",
   "description": "Desktop integration for Pomodoro application.",
-  "shell-version": ["46", "47"],
+  "shell-version": ["46", "47", "48"],
   "session-modes": ["user", "unlock-dialog"],
   "gettext-domain": "@GETTEXT_PACKAGE@",
   "url": "@PACKAGE_URL@",


### PR DESCRIPTION
## Pull request checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Other information

I did a quick test of this extension with GNOME Shell 48 Beta on Ubuntu 25.04 and the extension appeared to work with this change.

I suggest also having a look at https://gjs.guide/extensions/upgrading/gnome-shell-48.html to see if any other changes sound relevant.