### PR TITLE
Preliminary changes for GNOME 49 alpha.

### DIFF
--- a/plugins/gnome/extension/metadata.json.in
+++ b/plugins/gnome/extension/metadata.json.in
@@ -2,7 +2,7 @@
   "uuid": "@EXTENSION_UUID@",
   "name": "Pomodoro",
   "description": "Desktop integration for Pomodoro application.",
-  "shell-version": ["46", "47", "48"],
+  "shell-version": ["46", "47", "48", "49"],
   "session-modes": ["user", "unlock-dialog"],
   "gettext-domain": "@GETTEXT_PACKAGE@",
   "url": "@PACKAGE_URL@",

--- a/plugins/gnome/extension/notifications.js
+++ b/plugins/gnome/extension/notifications.js
@@ -30,6 +30,10 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as MessageTray from 'resource:///org/gnome/shell/ui/messageTray.js';
 import * as Params from 'resource:///org/gnome/shell/misc/params.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
+let DoNotDisturb;
+try {
+    DoNotDisturb = await import('resource:///org/gnome/shell/ui/status/doNotDisturb.js');
+} catch {}
 
 import {extension} from './extension.js';
 import {State} from './timer.js';
@@ -489,6 +493,17 @@ export const NotificationManager = class extends Signals.EventEmitter {
     }
 
     _showDoNotDisturbButton() {
+        if (DoNotDisturb) {
+            for (const indicator of Main.panel.statusArea.quickSettings._indicators.get_children()) {
+                if (indicator instanceof DoNotDisturb.Indicator) {
+                    for (const qs of indicator.quickSettingsItems) {
+                        qs.reactive = true;
+                    }
+                }
+            }
+            return;
+        }
+
         const dndButton = Main.panel.statusArea.dateMenu._messageList._dndButton;
         dndButton.show();
 
@@ -499,6 +514,17 @@ export const NotificationManager = class extends Signals.EventEmitter {
     }
 
     _hideDoNotDisturbButton() {
+        if (DoNotDisturb) {
+            for (const indicator of Main.panel.statusArea.quickSettings._indicators.get_children()) {
+                if (indicator instanceof DoNotDisturb.Indicator) {
+                    for (const qs of indicator.quickSettingsItems) {
+                        qs.reactive = false;
+                    }
+                }
+            }
+            return;
+        }
+
         const dndButton = Main.panel.statusArea.dateMenu._messageList._dndButton;
         dndButton.hide();
 


### PR DESCRIPTION
## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Preliminary changes for GNOME 49 alpha.
The DND button has moved from the message-list to the quick settings. Rather than hiding it, I've decided to make the button "disabled" to avoid changing the Quick Settings grid arrangement.
